### PR TITLE
Log-Sink verbosity level for error

### DIFF
--- a/pkg/cli-runtime/client.go
+++ b/pkg/cli-runtime/client.go
@@ -120,7 +120,7 @@ func (c *client) DeleteAllOf(ctx context.Context, obj crclient.Object, opts ...c
 }
 
 func (c *client) logError(err error) {
-	if err != nil {
+	if err != nil && c.log.V(2).Enabled() {
 		c.log.V(2).Error(err, "API Error")
 	}
 }

--- a/pkg/logger/log_sink.go
+++ b/pkg/logger/log_sink.go
@@ -36,7 +36,10 @@ func (*writerLogSink) Init(info logr.RuntimeInfo) {
 
 }
 
-func (*writerLogSink) Enabled(level int) bool {
+func (l *writerLogSink) Enabled(level int) bool {
+	if *l.level < int32(level) {
+		return false
+	}
 	return true
 }
 


### PR DESCRIPTION
Signed-off-by: Rashed Kamal <krashed@vmware.com>

Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Address bug related to Log-Sink verbosity level for error logs. 

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #55 

### Describe testing done for PR

- Unit Test passed
- Local test results below

_Default Verbosity Level_

```
➜  ~  tanzu apps workload list -n workspace
NAME                 APP                  READY   AGE
cat-app              <empty>              Ready   55d
tanzu-java-web-app   tanzu-java-web-app   Ready   55d
```

_Verbosity Level 2_

```
➜  ~  tanzu apps workload list -n workspace -v 2
API Request name:tanzu apps  host:https://xx.xxx.xx.xxx action:List
Results name:tanzu apps  objects:&{TypeMeta:{Kind: APIVersion:} ListMeta:{SelfLink: ResourceVersion:301498941 Continue: RemainingItemCount:<nil>} Items:[{TypeMeta:{Kind:Workload APIVersion:carto.run/v1alpha1} ObjectMeta:{Name:cat-app GenerateName: Namespace:workspace SelfLink: UID:49c70fce-2ec1-4572-bcf4-e16b39092b2b ResourceVersion:2825814 Generation:1 CreationTimestamp:2022-02-09 11:05:01 -0500 EST DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[apps.tanzu.vmware.com/workload-type:web] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[{Manager:tanzu-plugin-apps Operation:Update APIVersion:carto.run/v1alpha1 Time:2022-02-09 11:05:01 -0500 EST FieldsType:FieldsV1 FieldsV1:{"f:metadata":{"f:labels":{".":{},"f:apps.tanzu.vmware.com/workload-type":{}}},"f:spec":{".":{},"f:source":{".":{},"f:git":{".":{},"f:ref":{".":{},"f:branch":{}},"f:url":{}}}}} Subresource:} {Manager:cartographer Operation:Update APIVersion:carto.run/v1alpha1 Time:2022-02-09 11:05:04 -0500 EST FieldsType:FieldsV1 FieldsV1:{"f:status":{".":{},"f:conditions":{},"f:observedGeneration":{},"f:supplyChainRef":{".":{},"f:kind":{},"f:name":{}}}} Subresource:}]} Spec:{Params:[] Source:0xc000c61770 Build:<nil> Env:[] Image: Resources:nil ServiceAccountName: ServiceClaims:[]} Status:{ObservedGeneration:1 Conditions:[{Type:SupplyChainReady Status:True ObservedGeneration:0 LastTransitionTime:2022-02-09 11:05:01 -0500 EST Reason:Ready Message:} {Type:ResourcesSubmitted Status:True ObservedGeneration:0 LastTransitionTime:2022-02-09 11:05:52 -0500 EST Reason:ResourceSubmissionComplete Message:} {Type:Ready Status:True ObservedGeneration:0 LastTransitionTime:2022-02-09 11:05:52 -0500 EST Reason:Ready Message:}] SupplyChainRef:{Kind:ClusterSupplyChain Namespace: Name:source-to-url APIVersion:}}} {TypeMeta:{Kind:Workload APIVersion:carto.run/v1alpha1} ObjectMeta:{Name:tanzu-java-web-app GenerateName: Namespace:workspace SelfLink: UID:419371c3-bc5d-462d-8932-39a6484976c1 ResourceVersion:3738483 Generation:1 CreationTimestamp:2022-02-09 15:13:47 -0500 EST DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[app.kubernetes.io/part-of:tanzu-java-web-app apps.tanzu.vmware.com/workload-type:web] Annotations:map[] OwnerReferences:[] Finalizers:[] ClusterName: ManagedFields:[{Manager:tanzu-plugin-apps Operation:Update APIVersion:carto.run/v1alpha1 Time:2022-02-09 15:13:47 -0500 EST FieldsType:FieldsV1 FieldsV1:{"f:metadata":{"f:labels":{".":{},"f:app.kubernetes.io/part-of":{},"f:apps.tanzu.vmware.com/workload-type":{}}},"f:spec":{".":{},"f:source":{".":{},"f:git":{".":{},"f:ref":{".":{},"f:branch":{}},"f:url":{}}}}} Subresource:} {Manager:cartographer Operation:Update APIVersion:carto.run/v1alpha1 Time:2022-02-09 15:13:51 -0500 EST FieldsType:FieldsV1 FieldsV1:{"f:status":{".":{},"f:conditions":{},"f:observedGeneration":{},"f:supplyChainRef":{".":{},"f:kind":{},"f:name":{}}}} Subresource:}]} Spec:{Params:[] Source:0xc000c617d0 Build:<nil> Env:[] Image: Resources:nil ServiceAccountName: ServiceClaims:[]} Status:{ObservedGeneration:1 Conditions:[{Type:SupplyChainReady Status:True ObservedGeneration:0 LastTransitionTime:2022-02-09 15:13:47 -0500 EST Reason:Ready Message:} {Type:ResourcesSubmitted Status:True ObservedGeneration:0 LastTransitionTime:2022-02-09 15:14:58 -0500 EST Reason:ResourceSubmissionComplete Message:} {Type:Ready Status:True ObservedGeneration:0 LastTransitionTime:2022-02-09 15:14:58 -0500 EST Reason:Ready Message:}] SupplyChainRef:{Kind:ClusterSupplyChain Namespace: Name:source-to-url APIVersion:}}}]}
NAME                 APP                  READY   AGE
cat-app              <empty>              Ready   55d
tanzu-java-web-app   tanzu-java-web-app   Ready   55d
```

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

N/A
