### PR TITLE
Update output for list when there are no workloads

### DIFF
--- a/pkg/cli-runtime/printer/resource.go
+++ b/pkg/cli-runtime/printer/resource.go
@@ -99,7 +99,8 @@ func OutputResource(obj Object, format OutputFormat, scheme *runtime.Scheme) (st
 }
 
 func OutputResources(objList []Object, format OutputFormat, scheme *runtime.Scheme) (string, error) {
-	var updatedList []Object
+	updatedList := []Object{}
+
 	for _, o := range objList {
 		copy, err := setGVK(o, scheme)
 		if err != nil {

--- a/pkg/cli-runtime/printer/resource_test.go
+++ b/pkg/cli-runtime/printer/resource_test.go
@@ -828,6 +828,17 @@ func TestOutputResources(t *testing.T) {
 	}
 ]`,
 	}, {
+		name:         "empty list with json format",
+		outputFormat: printer.OutputFormatJson,
+		objs:         []printer.Object{},
+		want:         "[]",
+	}, {
+		name:         "empty list with yaml format",
+		outputFormat: printer.OutputFormatYaml,
+		objs:         []printer.Object{},
+		want: `---
+[]`,
+	}, {
 		name:         "not valid output",
 		outputFormat: "myFormat",
 		objs: []printer.Object{


### PR DESCRIPTION
Pull request

### What this PR does / why we need it

Previously empty list would generate `null` as output, this is updated to print empty array for both json and yaml.

### Which issue(s) this PR fixes

Fixes #12 

