### PR TITLE
Adding source info from workload spec to workload get command

### DIFF
--- a/pkg/commands/workload_get.go
+++ b/pkg/commands/workload_get.go
@@ -87,7 +87,7 @@ func (opts *WorkloadGetOptions) Exec(ctx context.Context, c *cli.Config) error {
 
 		export, err := printer.ExportResource(workload, format, c.Scheme)
 		if err != nil {
-			c.Eprintf("%s %s\n", printer.Serrorf("Failed export workload:"), err)
+			c.Eprintf("%s %s\n", printer.Serrorf("Failed to export workload:"), err)
 			return cli.SilenceError(err)
 		}
 		c.Printf("%s\n", export)
@@ -106,6 +106,30 @@ func (opts *WorkloadGetOptions) Exec(ctx context.Context, c *cli.Config) error {
 	}
 
 	c.Printf(printer.ResourceStatus(workload.Name, printer.FindCondition(workload.Status.Conditions, cartov1alpha1.WorkloadConditionReady)))
+
+	if workload.Spec.Image != "" || workload.Spec.Source != nil {
+		c.Printf("\n")
+		c.Printf("Source\n")
+
+		if workload.Spec.Image != "" {
+			if err := printer.WorkloadSourceImagePrinter(c.Stdout, workload); err != nil {
+				return err
+			}
+		}
+
+		if workload.Spec.Source != nil {
+			if workload.Spec.Source.Image != "" {
+				if err := printer.WorkloadLocalSourceImagePrinter(c.Stdout, workload); err != nil {
+					return err
+				}
+			}
+			if workload.Spec.Source.Git != nil {
+				if err := printer.WorkloadSourceGitPrinter(c.Stdout, workload); err != nil {
+					return err
+				}
+			}
+		}
+	}
 
 	if len(workload.Spec.ServiceClaims) > 0 {
 		c.Printf("\n")

--- a/pkg/commands/workload_get_test.go
+++ b/pkg/commands/workload_get_test.go
@@ -203,6 +203,149 @@ No pods found for workload.
 `,
 		},
 		{
+			Name: "show source info - git",
+			Args: []string{workloadName},
+			GivenObjects: []clitesting.Factory{
+				clitesting.Wrapper(&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      workloadName,
+						Namespace: defaultNamespace,
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: url,
+								Ref: cartov1alpha1.GitRef{
+									Branch: "master",
+									Tag:    "v1.0.0",
+									Commit: "abcdef",
+								},
+							},
+						},
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:    cartov1alpha1.WorkloadConditionReady,
+								Status:  metav1.ConditionFalse,
+								Reason:  "OopsieDoodle",
+								Message: "a hopefully informative message about what went wrong",
+								LastTransitionTime: metav1.Time{
+									Time: time.Date(2019, 6, 29, 01, 44, 05, 0, time.UTC),
+								},
+							},
+						},
+					},
+				}),
+			},
+			ExpectOutput: `
+# my-workload: OopsieDoodle
+---
+lastTransitionTime: "2019-06-29T01:44:05Z"
+message: a hopefully informative message about what went wrong
+reason: OopsieDoodle
+status: "False"
+type: Ready
+
+Source
+type:     git
+url:      https://example.com
+branch:   master
+tag:      v1.0.0
+commit:   abcdef
+
+No pods found for workload.
+`,
+		},
+		{
+			Name: "show source info - local path",
+			Args: []string{workloadName},
+			GivenObjects: []clitesting.Factory{
+				clitesting.Wrapper(&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      workloadName,
+						Namespace: defaultNamespace,
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Image: "my-registry/my-image:v1.0.0",
+						},
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:    cartov1alpha1.WorkloadConditionReady,
+								Status:  metav1.ConditionFalse,
+								Reason:  "OopsieDoodle",
+								Message: "a hopefully informative message about what went wrong",
+								LastTransitionTime: metav1.Time{
+									Time: time.Date(2019, 6, 29, 01, 44, 05, 0, time.UTC),
+								},
+							},
+						},
+					},
+				}),
+			},
+			ExpectOutput: `
+# my-workload: OopsieDoodle
+---
+lastTransitionTime: "2019-06-29T01:44:05Z"
+message: a hopefully informative message about what went wrong
+reason: OopsieDoodle
+status: "False"
+type: Ready
+
+Source
+type:    source image
+image:   my-registry/my-image:v1.0.0
+
+No pods found for workload.
+`,
+		},
+		{
+			Name: "show source info - image",
+			Args: []string{workloadName},
+			GivenObjects: []clitesting.Factory{
+				clitesting.Wrapper(&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      workloadName,
+						Namespace: defaultNamespace,
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Image: "docker.io/library/nginx:latest",
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:    cartov1alpha1.WorkloadConditionReady,
+								Status:  metav1.ConditionFalse,
+								Reason:  "OopsieDoodle",
+								Message: "a hopefully informative message about what went wrong",
+								LastTransitionTime: metav1.Time{
+									Time: time.Date(2019, 6, 29, 01, 44, 05, 0, time.UTC),
+								},
+							},
+						},
+					},
+				}),
+			},
+			ExpectOutput: `
+# my-workload: OopsieDoodle
+---
+lastTransitionTime: "2019-06-29T01:44:05Z"
+message: a hopefully informative message about what went wrong
+reason: OopsieDoodle
+status: "False"
+type: Ready
+
+Source
+type:    image
+image:   docker.io/library/nginx:latest
+
+No pods found for workload.
+`,
+		},
+		{
 			Name: "show pods",
 			Args: []string{workloadName},
 			GivenObjects: []clitesting.Factory{

--- a/pkg/printer/workload_source_printer.go
+++ b/pkg/printer/workload_source_printer.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer
+
+import (
+	"io"
+
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+
+	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/printer/table"
+)
+
+func WorkloadSourceImagePrinter(w io.Writer, workload *cartov1alpha1.Workload) error {
+	printImageInfo := func(workload *cartov1alpha1.Workload, printOpts table.PrintOptions) ([]metav1beta1.TableRow, error) {
+		sourceRow := metav1beta1.TableRow{
+			Cells: []interface{}{
+				"type:",
+				"image",
+			},
+		}
+
+		imageRow := metav1beta1.TableRow{
+			Cells: []interface{}{
+				"image:",
+				workload.Spec.Image,
+			},
+		}
+
+		rows := []metav1beta1.TableRow{sourceRow, imageRow}
+		return rows, nil
+	}
+
+	tablePrinter := table.NewTablePrinter(table.PrintOptions{NoHeaders: true}).With(func(h table.PrintHandler) {
+		h.TableHandler(nil, printImageInfo)
+	})
+
+	return tablePrinter.PrintObj(workload, w)
+}
+
+func WorkloadLocalSourceImagePrinter(w io.Writer, workload *cartov1alpha1.Workload) error {
+	printLocalSourceInfo := func(workload *cartov1alpha1.Workload, printOpts table.PrintOptions) ([]metav1beta1.TableRow, error) {
+		sourceRow := metav1beta1.TableRow{
+			Cells: []interface{}{
+				"type:",
+				"source image",
+			},
+		}
+
+		rows := []metav1beta1.TableRow{sourceRow}
+
+		if workload.Spec.Source.Subpath != "" {
+			subPathRow := metav1beta1.TableRow{
+				Cells: []interface{}{
+					"sub-path:",
+					workload.Spec.Source.Subpath,
+				},
+			}
+			rows = append(rows, subPathRow)
+		}
+
+		imageRow := metav1beta1.TableRow{
+			Cells: []interface{}{
+				"image:",
+				workload.Spec.Source.Image,
+			},
+		}
+		rows = append(rows, imageRow)
+
+		return rows, nil
+	}
+	tablePrinter := table.NewTablePrinter(table.PrintOptions{NoHeaders: true}).With(func(h table.PrintHandler) {
+		h.TableHandler(nil, printLocalSourceInfo)
+	})
+
+	return tablePrinter.PrintObj(workload, w)
+}
+
+func WorkloadSourceGitPrinter(w io.Writer, workload *cartov1alpha1.Workload) error {
+	printGitInfo := func(workload *cartov1alpha1.Workload, printOpts table.PrintOptions) ([]metav1beta1.TableRow, error) {
+		sourceRow := metav1beta1.TableRow{
+			Cells: []interface{}{
+				"type:",
+				"git",
+			},
+		}
+
+		urlRow := metav1beta1.TableRow{
+			Cells: []interface{}{
+				"url:",
+				workload.Spec.Source.Git.URL,
+			},
+		}
+
+		rows := []metav1beta1.TableRow{sourceRow, urlRow}
+
+		if workload.Spec.Source.Subpath != "" {
+			subPathRow := metav1beta1.TableRow{
+				Cells: []interface{}{
+					"sub-path:",
+					workload.Spec.Source.Subpath,
+				},
+			}
+			rows = append(rows, subPathRow)
+		}
+
+		if workload.Spec.Source.Git.Ref.Branch != "" {
+			branchRow := metav1beta1.TableRow{
+				Cells: []interface{}{
+					"branch:",
+					workload.Spec.Source.Git.Ref.Branch,
+				},
+			}
+			rows = append(rows, branchRow)
+		}
+
+		if workload.Spec.Source.Git.Ref.Tag != "" {
+			tagRow := metav1beta1.TableRow{
+				Cells: []interface{}{
+					"tag:",
+					workload.Spec.Source.Git.Ref.Tag,
+				},
+			}
+			rows = append(rows, tagRow)
+		}
+
+		if workload.Spec.Source.Git.Ref.Commit != "" {
+			commitRow := metav1beta1.TableRow{
+				Cells: []interface{}{
+					"commit:",
+					workload.Spec.Source.Git.Ref.Commit,
+				},
+			}
+			rows = append(rows, commitRow)
+		}
+
+		return rows, nil
+	}
+
+	tablePrinter := table.NewTablePrinter(table.PrintOptions{NoHeaders: true}).With(func(h table.PrintHandler) {
+		h.TableHandler(nil, printGitInfo)
+	})
+
+	return tablePrinter.PrintObj(workload, w)
+}

--- a/pkg/printer/workload_source_printer_test.go
+++ b/pkg/printer/workload_source_printer_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/printer"
+)
+
+func TestWorkloadSourceImagePrinter(t *testing.T) {
+	defaultNamespace := "default"
+	workloadName := "my-workload"
+
+	tests := []struct {
+		name           string
+		testWorkload   *cartov1alpha1.Workload
+		expectedOutput string
+	}{{
+		name: "built from image",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Image: "my-image",
+			},
+		},
+		expectedOutput: `
+type:    image
+image:   my-image
+`,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			if err := printer.WorkloadSourceImagePrinter(output, test.testWorkload); err != nil {
+				t.Errorf("WorkloadSourcePrinter() expected no error, got %v", err)
+			}
+			outputString := output.String()
+			if diff := cmp.Diff(strings.TrimPrefix(test.expectedOutput, "\n"), outputString); diff != "" {
+				t.Errorf("Unexpected output (-expected, +actual): %s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadLocalSourceImagePrinter(t *testing.T) {
+	defaultNamespace := "default"
+	workloadName := "my-workload"
+
+	tests := []struct {
+		name           string
+		testWorkload   *cartov1alpha1.Workload
+		expectedOutput string
+	}{{
+		name: "built from image",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Source: &cartov1alpha1.Source{
+					Image: "my-image",
+				},
+			},
+		},
+		expectedOutput: `
+type:    source image
+image:   my-image
+`,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			if err := printer.WorkloadLocalSourceImagePrinter(output, test.testWorkload); err != nil {
+				t.Errorf("WorkloadSourcePrinter() expected no error, got %v", err)
+			}
+			outputString := output.String()
+			if diff := cmp.Diff(strings.TrimPrefix(test.expectedOutput, "\n"), outputString); diff != "" {
+				t.Errorf("Unexpected output (-expected, +actual): %s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadSourceGitPrinter(t *testing.T) {
+	defaultNamespace := "default"
+	workloadName := "my-workload"
+
+	tests := []struct {
+		name           string
+		testWorkload   *cartov1alpha1.Workload
+		expectedOutput string
+	}{{
+		name: "built from git all specs",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Source: &cartov1alpha1.Source{
+					Subpath: "my-subpath",
+					Git: &cartov1alpha1.GitSource{
+						URL: "https://example.com/my-repo",
+						Ref: cartov1alpha1.GitRef{
+							Branch: "my-branch",
+							Tag:    "my-tag",
+							Commit: "my-commit",
+						},
+					},
+				},
+			},
+		},
+		expectedOutput: `
+type:       git
+url:        https://example.com/my-repo
+sub-path:   my-subpath
+branch:     my-branch
+tag:        my-tag
+commit:     my-commit
+`,
+	}, {
+		name: "built from git some specs",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Source: &cartov1alpha1.Source{
+					Git: &cartov1alpha1.GitSource{
+						URL: "https://example.com/my-repo",
+						Ref: cartov1alpha1.GitRef{
+							Branch: "my-branch",
+						},
+					},
+				},
+			},
+		},
+		expectedOutput: `
+type:     git
+url:      https://example.com/my-repo
+branch:   my-branch
+`,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			if err := printer.WorkloadSourceGitPrinter(output, test.testWorkload); err != nil {
+				t.Errorf("WorkloadSourcePrinter() expected no error, got %v", err)
+			}
+			outputString := output.String()
+			if diff := cmp.Diff(strings.TrimPrefix(test.expectedOutput, "\n"), outputString); diff != "" {
+				t.Errorf("Unexpected output (-expected, +actual): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Add source info when retrieving a workload with apps workload get command. In this PR, sub-path is also added to displayed output

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #10 
Fixes #21 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

Signed-off by: Wendy Arango warango@vmware.com