### PR TITLE
Adding yml to accepted output formats

### DIFF
--- a/docs/command-reference/tanzu_apps_workload_get.md
+++ b/docs/command-reference/tanzu_apps_workload_get.md
@@ -22,7 +22,7 @@ tanzu apps workload get my-workload
       --export           export workload in yaml format
   -h, --help             help for get
   -n, --namespace name   kubernetes namespace (defaulted from kube config)
-  -o, --output string    output the Workload formatted. Supported formats: "json", "yaml"
+  -o, --output string    output the Workload formatted. Supported formats: "json", "yaml", "yml"
 ```
 
 ### Options inherited from parent commands

--- a/docs/command-reference/tanzu_apps_workload_list.md
+++ b/docs/command-reference/tanzu_apps_workload_list.md
@@ -24,7 +24,7 @@ tanzu apps workload list --all-namespaces
       --app name         application name the workload is a part of
   -h, --help             help for list
   -n, --namespace name   kubernetes namespace (defaulted from kube config)
-  -o, --output string    output the Workloads formatted. Supported formats: "json", "yaml"
+  -o, --output string    output the Workloads formatted. Supported formats: "json", "yaml", "yml"
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cli-runtime/printer/resource.go
+++ b/pkg/cli-runtime/printer/resource.go
@@ -37,6 +37,7 @@ type OutputFormat string
 const (
 	OutputFormatJson = "json"
 	OutputFormatYaml = "yaml"
+	OutputFormatYml  = "yml"
 )
 
 type Object interface {
@@ -117,7 +118,7 @@ func printObject(obj interface{}, format OutputFormat) (string, error) {
 	case OutputFormatJson:
 		b, err := json.MarshalIndent(obj, "", "\t")
 		return strings.TrimSpace(string(b)), err
-	case OutputFormatYaml:
+	case OutputFormatYaml, OutputFormatYml:
 		b, err := yaml.Marshal(obj)
 		return fmt.Sprintf("---\n%s", strings.TrimSpace(string(b))), err
 	default:

--- a/pkg/commands/workload_get.go
+++ b/pkg/commands/workload_get.go
@@ -60,7 +60,7 @@ func (opts *WorkloadGetOptions) Validate(ctx context.Context) validation.FieldEr
 	}
 
 	if opts.Output != "" {
-		errs = errs.Also(validation.Enum(opts.Output, flags.OutputFlagName, []string{printer.OutputFormatJson, printer.OutputFormatYaml}))
+		errs = errs.Also(validation.Enum(opts.Output, flags.OutputFlagName, []string{printer.OutputFormatJson, printer.OutputFormatYaml, printer.OutputFormatYml}))
 	}
 
 	return errs
@@ -195,7 +195,7 @@ func NewWorkloadGetCommand(ctx context.Context, c *cli.Config) *cobra.Command {
 
 	cli.NamespaceFlag(ctx, cmd, c, &opts.Namespace)
 	cmd.Flags().BoolVar(&opts.Export, cli.StripDash(flags.ExportFlagName), false, "export workload in yaml format")
-	cmd.Flags().StringVarP(&opts.Output, cli.StripDash(flags.OutputFlagName), "o", "", "output the Workload formatted. Supported formats: \"json\", \"yaml\"")
+	cmd.Flags().StringVarP(&opts.Output, cli.StripDash(flags.OutputFlagName), "o", "", "output the Workload formatted. Supported formats: \"json\", \"yaml\", \"yml\"")
 
 	return cmd
 }

--- a/pkg/commands/workload_get_test.go
+++ b/pkg/commands/workload_get_test.go
@@ -94,7 +94,7 @@ func TestWorkloadGetOptionsValidate(t *testing.T) {
 				Name:      "my-workload",
 				Output:    "myFormat",
 			},
-			ExpectFieldErrors: validation.EnumInvalidValue("myFormat", flags.OutputFlagName, []string{"json", "yaml"}),
+			ExpectFieldErrors: validation.EnumInvalidValue("myFormat", flags.OutputFlagName, []string{"json", "yaml", "yml"}),
 		},
 	}
 

--- a/pkg/commands/workload_list.go
+++ b/pkg/commands/workload_list.go
@@ -63,7 +63,7 @@ func (opts *WorkloadListOptions) Validate(ctx context.Context) validation.FieldE
 	}
 
 	if opts.Output != "" {
-		errs = errs.Also(validation.Enum(opts.Output, flags.OutputFlagName, []string{printer.OutputFormatJson, printer.OutputFormatYaml}))
+		errs = errs.Also(validation.Enum(opts.Output, flags.OutputFlagName, []string{printer.OutputFormatJson, printer.OutputFormatYaml, printer.OutputFormatYml}))
 	}
 
 	return errs
@@ -133,7 +133,7 @@ List workloads in a namespace or across all namespaces.
 
 	cli.AllNamespacesFlag(ctx, cmd, c, &opts.Namespace, &opts.AllNamespaces)
 	cmd.Flags().StringVar(&opts.App, cli.StripDash(flags.AppFlagName), "", "application `name` the workload is a part of")
-	cmd.Flags().StringVarP(&opts.Output, cli.StripDash(flags.OutputFlagName), "o", "", "output the Workloads formatted. Supported formats: \"json\", \"yaml\"")
+	cmd.Flags().StringVarP(&opts.Output, cli.StripDash(flags.OutputFlagName), "o", "", "output the Workloads formatted. Supported formats: \"json\", \"yaml\", \"yml\"")
 
 	return cmd
 }

--- a/pkg/commands/workload_list_test.go
+++ b/pkg/commands/workload_list_test.go
@@ -76,7 +76,7 @@ func TestWorkloadListOptionsValidate(t *testing.T) {
 				Namespace: "default",
 				Output:    "myFormat",
 			},
-			ExpectFieldErrors: validation.EnumInvalidValue("myFormat", flags.OutputFlagName, []string{"json", "yaml"}),
+			ExpectFieldErrors: validation.EnumInvalidValue("myFormat", flags.OutputFlagName, []string{"json", "yaml", "yml"}),
 		},
 	}
 
@@ -145,6 +145,32 @@ test-workload   <empty>   <unknown>   <unknown>
 		}
 	}
 ]
+`,
+		},
+		{
+			Name: "lists all items in yml format",
+			Args: []string{flags.OutputFlagName, "yml"},
+			GivenObjects: []clitesting.Factory{
+				clitesting.Wrapper(&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              workloadName,
+						Namespace:         defaultNamespace,
+						CreationTimestamp: metav1.Date(2021, time.September, 10, 15, 00, 00, 00, time.UTC),
+					},
+				}),
+			},
+			ExpectOutput: `
+---
+- apiVersion: carto.run/v1alpha1
+  kind: Workload
+  metadata:
+    creationTimestamp: "2021-09-10T15:00:00Z"
+    name: test-workload
+    namespace: default
+    resourceVersion: "999"
+  spec: {}
+  status:
+    supplyChainRef: {}
 `,
 		},
 		{

--- a/pkg/printer/aliases.go
+++ b/pkg/printer/aliases.go
@@ -35,3 +35,4 @@ type OutputFormat = printer.OutputFormat
 
 var OutputFormatJson = printer.OutputFormatJson
 var OutputFormatYaml = printer.OutputFormatYaml
+var OutputFormatYml = printer.OutputFormatYml


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Add support for yml extension when user wants to output a resource through workload get or workload list commands.

Output will be same if user wants to show it with yaml format.

Usage example:
`tanzu apps workload get my-workload -oyml`
`tanzu apps workload list -oyml`

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #72 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Unit testing in source code
- Used commands in local cluster

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Signed-off by: Wendy Arango warango@vmware.com
