### PR TITLE
Update workload commands list/get/update when bogus namespace is passed

### DIFF
--- a/pkg/apis/cartographer/v1alpha1/groupversion_info.go
+++ b/pkg/apis/cartographer/v1alpha1/groupversion_info.go
@@ -40,3 +40,8 @@ var (
 
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}

--- a/pkg/apis/cartographer/v1alpha1/groupversion_info_test.go
+++ b/pkg/apis/cartographer/v1alpha1/groupversion_info_test.go
@@ -56,3 +56,15 @@ func TestGetGroupVersionKind(t *testing.T) {
 		})
 	}
 }
+
+func TestResource(t *testing.T) {
+	resourceName := "test"
+	expectResource := schema.GroupResource{
+		Group:    GroupName,
+		Resource: resourceName,
+	}
+	actualResource := Resource(resourceName)
+	if diff := cmp.Diff(expectResource, actualResource); diff != "" {
+		t.Errorf("Resource() (-want, +got) = %v", diff)
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

New behaviour:

```
tanzu apps workload update pc -n ns2 
Error: namespace "ns2" not found, it may not exist or user does not have permissions to read it.
Error: exit status 1

✖  exit status 1 
```

```
tanzu apps workload list -n ns2                 
Error: namespace "ns2" not found, it may not exist or user does not have permissions to read it.
Error: exit status 1

✖  exit status 1 
```

```
tanzu apps workload get pc -n ns2               
Error: namespace "ns2" not found, it may not exist or user does not have permissions to read it.
Error: exit status 1

✖  exit status 1 
```
### Which issue(s) this PR fixes
Fixes #18 


### Discussion:

For commands `create/apply` sub-command, when namespace does not exist the above error is not thrown. This is because of `NamespaceAutoProvision` on https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/. Admission controller can potentially create namespace in a cluster if Workload object includes namespace that does not exist.
cc @heyjcollins @scothis @rashedkvm 