### PR TITLE
Update k8s testing version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,9 +72,9 @@ jobs:
     strategy:
       matrix:
         k8s:
-        - 1.20.2
-        - 1.21.2
-        - 1.22.5
+        - 1.21.10
+        - 1.22.7
+        - 1.23.5
     env:
       REGISTRY_NAME: registry.local
       REGISTRY_PORT: 5000


### PR DESCRIPTION
Pull request


Update k8s version for CI testing.

Tag v1.24 is not present for kind yet.