### PR TITLE
subpath field is not removed when submitting workload from file

### DIFF
--- a/pkg/apis/cartographer/v1alpha1/workload_helpers.go
+++ b/pkg/apis/cartographer/v1alpha1/workload_helpers.go
@@ -78,8 +78,8 @@ func (w *Workload) loadAndValidateDocuments(in io.Reader) error {
 	return nil
 }
 
-func (w *Workload) MergeServiceAccountName(serviceAccountName string) {
-	w.Spec.ServiceAccountName = serviceAccountName
+func (w *WorkloadSpec) MergeServiceAccountName(serviceAccountName string) {
+	w.ServiceAccountName = serviceAccountName
 }
 
 func (w *Workload) Merge(updates *Workload) {
@@ -162,6 +162,9 @@ func (w *WorkloadSpec) Merge(updates *WorkloadSpec) {
 		}
 		if s.Image != "" {
 			w.MergeSourceImage(s.Image)
+		}
+		if s.Subpath != "" {
+			w.MergeSubPath(s.Subpath)
 		}
 	}
 	for _, e := range updates.Env {

--- a/pkg/commands/testdata/workload-subPath.yaml
+++ b/pkg/commands/testdata/workload-subPath.yaml
@@ -1,0 +1,25 @@
+# Copyright 2021 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  name: service
+spec:
+  source:
+    subPath: ./app
+    git:
+      url: https://github.com/spring-projects/spring-petclinic.git
+      ref:
+        branch: main

--- a/pkg/commands/workload_apply.go
+++ b/pkg/commands/workload_apply.go
@@ -98,8 +98,9 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 	workload.Name = opts.Name
 	workload.Namespace = opts.Namespace
 	if opts.FilePath != "" {
-		workload.MergeServiceAccountName(fileWorkload.Spec.ServiceAccountName)
+		workload.Spec.MergeServiceAccountName(fileWorkload.Spec.ServiceAccountName)
 	}
+
 	workload.Merge(fileWorkload)
 
 	opts.ApplyOptionsToWorkload(ctx, workload)

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -173,6 +173,94 @@ Created workload "my-workload"
 `,
 		},
 		{
+			Name: "Update git source with subPath from file",
+			Args: []string{workloadName, flags.FilePathFlagName, "./testdata/workload-subPath.yaml", flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
+						d.Source(&cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: "https://github.com/spring-projects/spring-petclinic.git",
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+						})
+					}),
+			},
+			ExpectUpdates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: "https://github.com/spring-projects/spring-petclinic.git",
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+							Subpath: "./app",
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+Update workload:
+...
+  9,  9   |    git:
+ 10, 10   |      ref:
+ 11, 11   |        branch: main
+ 12, 12   |      url: https://github.com/spring-projects/spring-petclinic.git
+     13 + |    subPath: ./app
+
+Updated workload "my-workload"
+`,
+		},
+		{
+			Name: "Create git source with subPath from file",
+			Args: []string{workloadName, flags.FilePathFlagName, "./testdata/workload-subPath.yaml", flags.YesFlagName},
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: "https://github.com/spring-projects/spring-petclinic.git",
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+							Subpath: "./app",
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  name: my-workload
+      6 + |  namespace: default
+      7 + |spec:
+      8 + |  source:
+      9 + |    git:
+     10 + |      ref:
+     11 + |        branch: main
+     12 + |      url: https://github.com/spring-projects/spring-petclinic.git
+     13 + |    subPath: ./app
+
+Created workload "my-workload"
+`,
+		},
+		{
 			Name:        "subPath with no source",
 			Args:        []string{workloadName, flags.SubPathFlagName, "./app", flags.YesFlagName},
 			ShouldError: true,

--- a/pkg/commands/workload_update.go
+++ b/pkg/commands/workload_update.go
@@ -97,7 +97,7 @@ func (opts *WorkloadUpdateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	}
 	currentWorkload := workload.DeepCopy()
 	if opts.FilePath != "" {
-		workload.MergeServiceAccountName(fileWorkload.Spec.ServiceAccountName)
+		workload.Spec.MergeServiceAccountName(fileWorkload.Spec.ServiceAccountName)
 	}
 	workload.Merge(fileWorkload)
 


### PR DESCRIPTION
Pull request
subpath field is not ignored when submitting workload from file(both while creating & updating)

### What this PR does / why we need it
Fixes #88 

### Describe testing done for PR
- create workload with subPath
- export the workload into a file
- apply the workload again, subPath should not be deleted
