### PR TITLE
feat: support shortnames for carto's workload and cluster supplychain

### DIFF
--- a/pkg/commands/clustersupplychain.go
+++ b/pkg/commands/clustersupplychain.go
@@ -31,7 +31,7 @@ func NewClusterSupplyChainCommand(ctx context.Context, c *cli.Config) *cobra.Com
 		// 		Long: strings.TrimSpace(`
 		// <todo>
 		// `),
-		Aliases: []string{"cluster-supply-chains", "clustersupplychain", "clustersupplychains"},
+		Aliases: []string{"cluster-supply-chains", "clustersupplychain", "clustersupplychains", "csc"},
 	}
 
 	cmd.AddCommand(NewClusterSupplyChainListCommand(ctx, c))

--- a/pkg/commands/workload.go
+++ b/pkg/commands/workload.go
@@ -56,7 +56,7 @@ Workload configuration includes:
 - environment variables
 - services to bind
 `),
-		Aliases: []string{"workloads"},
+		Aliases: []string{"workloads", "wld"},
 	}
 
 	cmd.AddCommand(NewWorkloadListCommand(ctx, c))


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Adds alias support to short-names of carto workload and cluster supply chain

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #96 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Local test of the command

![image](https://user-images.githubusercontent.com/2386675/167705734-04b140b2-3b32-41ed-b4b4-f022954d26b3.png)


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
