### PR TITLE
Add a msg for workload sub commands when no source is present

### DIFF
--- a/pkg/commands/workload.go
+++ b/pkg/commands/workload.go
@@ -156,21 +156,6 @@ func (opts *WorkloadOptions) Validate(ctx context.Context) validation.FieldError
 		errs = errs.Also(validation.CompareQuantity(opts.LimitMemory, opts.RequestMemory, flags.RequestMemoryFlagName))
 	}
 
-	// source options are mutually exclusive
-	source := []string{}
-	if opts.GitBranch != "" || opts.GitCommit != "" || opts.GitRepo != "" || opts.GitTag != "" {
-		source = append(source, flags.GitFlagWildcard)
-	}
-	if opts.SourceImage != "" {
-		source = append(source, flags.SourceImageFlagName)
-	}
-	if opts.Image != "" {
-		source = append(source, flags.ImageFlagName)
-	}
-	if len(source) > 1 {
-		errs = errs.Also(validation.ErrMultipleOneOf(source...))
-	}
-
 	return errs
 }
 
@@ -459,7 +444,9 @@ func (opts *WorkloadOptions) Update(ctx context.Context, c *cli.Config, currentW
 	}
 	c.Printf("Update workload:\n")
 	c.Printf("%s\n", difference)
-
+	if !workload.IsSourceFound() {
+		c.Printf("NOTICE: no source code or image has been specified for this workload.\n\n")
+	}
 	if !opts.Yes {
 		if opts.FilePath == "-" {
 			c.Errorf("Skipping workload, cannot confirm intent. Run command with %s flag to confirm intent when providing input from stdin\n", flags.YesFlagName)
@@ -505,7 +492,9 @@ func (opts *WorkloadOptions) Create(ctx context.Context, c *cli.Config, workload
 
 	c.Printf("Create workload:\n")
 	c.Printf("%s\n", diff)
-
+	if !workload.IsSourceFound() {
+		c.Printf("NOTICE: no source code or image has been specified for this workload.\n\n")
+	}
 	if !opts.Yes {
 		if opts.FilePath == "-" {
 			c.Errorf("Skipping workload, cannot confirm intent. Run command with %s flag to confirm intent when providing input from stdin\n", flags.YesFlagName)

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -1031,17 +1031,10 @@ Workload is unchanged, skipping update
 `,
 		},
 		{
-			Name: "invalid resource",
+			Name: "no source resource",
 			Args: []string{workloadName},
 			GivenObjects: []client.Object{
 				parent,
-			},
-			ShouldError: true,
-			CleanUp: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) error {
-				if expected, actual := false, cmd.SilenceUsage; expected != actual {
-					t.Errorf("expected cmd.SilenceUsage to be %t, actually %t", expected, actual)
-				}
-				return nil
 			},
 		},
 		{

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -107,15 +107,8 @@ func TestWorkloadCreateCommand(t *testing.T) {
 			ShouldError: true,
 		},
 		{
-			Name:        "missing source",
-			Args:        []string{workloadName},
-			ShouldError: true,
-			CleanUp: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) error {
-				if expected, actual := false, cmd.SilenceUsage; expected != actual {
-					t.Errorf("expected cmd.SilenceUsage to be %t, actually %t", expected, actual)
-				}
-				return nil
-			},
+			Name: "no source",
+			Args: []string{workloadName},
 		},
 		{
 			Name: "dry run",

--- a/pkg/commands/workload_update_test.go
+++ b/pkg/commands/workload_update_test.go
@@ -131,17 +131,10 @@ Workload is unchanged, skipping update
 `,
 		},
 		{
-			Name: "invalid resource",
+			Name: "no source",
 			Args: []string{workloadName},
 			GivenObjects: []client.Object{
 				parent,
-			},
-			ShouldError: true,
-			CleanUp: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) error {
-				if expected, actual := false, cmd.SilenceUsage; expected != actual {
-					t.Errorf("expected cmd.SilenceUsage to be %t, actually %t", expected, actual)
-				}
-				return nil
 			},
 		},
 		{


### PR DESCRIPTION
### What this PR does / why we need it
Add a info level msg for workload create/apply/update when no source is present

### Which issue(s) this PR fixes

Fixes #154 

### Describe testing done for PR
![Screen Shot 2022-06-03 at 1 25 17 PM](https://user-images.githubusercontent.com/9938926/171947447-0851a381-96ea-470f-b9ed-b09dd64eace1.png)

### Additional information or special notes for your reviewer
- if workload is created with no source but subPath is provided : fails

