### PR TITLE
Exclude jar and zip files in Grype scan

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
         echo "##[endgroup]"
         echo "##[group]Scan source ."
-          grype dir:. --exclude ./hack,./vendor --exclude './pkg/**/*.jar' --exclude './pkg/**/*.zip'
+          grype dir:. --exclude ./hack,./vendor --exclude '**/testdata/**'
         echo "##[endgroup]"
     - name: Install tanzu cli
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
         echo "##[endgroup]"
         echo "##[group]Scan source ."
-          grype dir:. --exclude ./hack,./vendor
+          grype dir:. --exclude ./hack,./vendor --exclude './pkg/**/*.jar' --exclude './pkg/**/*.zip'
         echo "##[endgroup]"
     - name: Install tanzu cli
       run: |


### PR DESCRIPTION

### What this PR does / why we need it
Update CI file to exclude jar and zip files in Grype scan. This should remove the warning msgs from CI logs.