### PR TITLE
Delete info message pointing to workload get after wait error

### DIFF
--- a/pkg/commands/workload_apply.go
+++ b/pkg/commands/workload_apply.go
@@ -184,7 +184,6 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 		if err := wait.Race(ctx, opts.WaitTimeout, workers); err != nil {
 			if err == context.DeadlineExceeded {
 				c.Printf("%s timeout after %s waiting for %q to become ready\n", printer.Serrorf("Error:"), opts.WaitTimeout, workload.Name)
-				c.Infof("To view status run: tanzu apps workload get %s %s %s\n", workload.Name, flags.NamespaceFlagName, opts.Namespace)
 				return cli.SilenceError(err)
 			}
 			c.Eprintf("%s %s\n", printer.Serrorf("Error:"), err)

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -345,7 +345,6 @@ To get status: "tanzu apps workload get my-workload"
 
 Waiting for workload "my-workload" to become ready...
 Error: timeout after 1ns waiting for "my-workload" to become ready
-To view status run: tanzu apps workload get my-workload --namespace default
 `,
 		},
 		{
@@ -1268,7 +1267,6 @@ To get status: "tanzu apps workload get my-workload"
 
 Waiting for workload "my-workload" to become ready...
 Error: timeout after 1ns waiting for "my-workload" to become ready
-To view status run: tanzu apps workload get my-workload --namespace default
 `,
 		},
 		{

--- a/pkg/commands/workload_create.go
+++ b/pkg/commands/workload_create.go
@@ -153,7 +153,6 @@ func (opts *WorkloadCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		if err := wait.Race(ctx, opts.WaitTimeout, workers); err != nil {
 			if err == context.DeadlineExceeded {
 				c.Printf("%s timeout after %s waiting for %q to become ready\n", printer.Serrorf("Error:"), opts.WaitTimeout, opts.Name)
-				c.Infof("To view status run: tanzu apps workload get %s %s %s\n", opts.Name, flags.NamespaceFlagName, opts.Namespace)
 				return cli.SilenceError(err)
 			}
 			c.Eprintf("%s %s\n", printer.Serrorf("Error:"), err)

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -267,7 +267,6 @@ To get status: "tanzu apps workload get my-workload"
 
 Waiting for workload "my-workload" to become ready...
 Error: timeout after 1ns waiting for "my-workload" to become ready
-To view status run: tanzu apps workload get my-workload --namespace default
 `,
 		},
 		{

--- a/pkg/commands/workload_update.go
+++ b/pkg/commands/workload_update.go
@@ -174,7 +174,6 @@ func (opts *WorkloadUpdateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		if err := wait.Race(ctx, opts.WaitTimeout, workers); err != nil {
 			if err == context.DeadlineExceeded {
 				c.Printf("%s timeout after %s waiting for %q to become ready\n", printer.Serrorf("Error:"), opts.WaitTimeout, workload.Name)
-				c.Infof("To view status run: tanzu apps workload get %s %s %s\n", workload.Name, flags.NamespaceFlagName, opts.Namespace)
 				return cli.SilenceError(err)
 			}
 			c.Eprintf("%s %s\n", printer.Serrorf("Error:"), err)

--- a/pkg/commands/workload_update_test.go
+++ b/pkg/commands/workload_update_test.go
@@ -465,7 +465,6 @@ To get status: "tanzu apps workload get my-workload"
 
 Waiting for workload "my-workload" to become ready...
 Error: timeout after 1ns waiting for "my-workload" to become ready
-To view status run: tanzu apps workload get my-workload --namespace default
 `,
 		},
 		{


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
remove redundant message pointing to workload get when there is an error after wait in workload create/update/apply

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #183 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Updated unit testing
- Checked commands behaviour in local cluster

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Signed-off-by: Wendy Arango <warango@vmware.com>