### PR TITLE
build: enable arm64 build for linux and darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ TANZU_PLUGIN_PUBLISH_PATH ?= $(ARTIFACTS_DIR)/published
 
 
 # Add supported OS-ARCHITECTURE combinations here
-ENVS ?= linux-amd64 windows-amd64 darwin-amd64 # linux-arm64 darwin-arm64
+ENVS ?= linux-amd64 windows-amd64 darwin-amd64 linux-arm64 darwin-arm64
 
 BUILD_JOBS := $(addprefix build-,${ENVS})
 PUBLISH_JOBS := $(addprefix publish-,${ENVS})


### PR DESCRIPTION
Pull request

### What this PR does / why we need it

Add arm build to output publish binaries 

### Which issue(s) this PR fixes

Fixes #195 

### Describe testing done for PR

Tested on Raspberry Pi 4b, tanzu framework built in the RBP4 and the plugin built in a CI and installed in the RBP4

![image](https://user-images.githubusercontent.com/2386675/175551316-69710f53-2c2c-4288-a30a-676696d4014e.png)


### Additional information or special notes for your reviewer

Pending testing  ARM MacOS