### PR TITLE
bug: Delete unused flag coming from imgpkg

### DIFF
--- a/cmd/plugin/apps/main.go
+++ b/cmd/plugin/apps/main.go
@@ -96,6 +96,9 @@ func main() {
 	p.Cmd.PersistentFlags().StringVar(&c.CurrentContext, cli.StripDash(flags.ContextFlagName), "", "`name` of the kubeconfig context to use (default is current-context defined by kubeconfig)")
 	p.Cmd.PersistentFlags().BoolVar(&color.NoColor, cli.StripDash(flags.NoColorFlagName), color.NoColor, "disable color output in terminals")
 	p.Cmd.PersistentFlags().Int32VarP(c.Verbose, cli.StripDash(flags.VerboseLevelFlagName), "v", 1, "number for the log level verbosity")
+	if markHiddenErr := p.Cmd.LocalFlags().MarkHidden("azure-container-registry-config"); markHiddenErr != nil {
+		c.Eprintf("%s %s: %s\n", printer.Serrorf("Error:"), "Unable to hide plugin unused flags", markHiddenErr)
+	}
 
 	cobra.OnInitialize(func() {
 		// sync survey and faith option to disable color


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Hide `azure-container-registry-config`, that comes from imgpkg library and it's not used in apps plugin

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #171 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Built in local cluster to check flag is not printed in help message.

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Signed-off-by: Wendy Arango <warango@vmware.com>
Co-authored-by: Shash Reddy <shashwathi@users.noreply.github.com>