### PR TITLE
Adding healthy column to workload get resources output

### DIFF
--- a/pkg/apis/cartographer/v1alpha1/workload.go
+++ b/pkg/apis/cartographer/v1alpha1/workload.go
@@ -27,6 +27,7 @@ const (
 	WorkloadReady             = "Ready"
 	WorkloadSupplyChainReady  = "SupplyChainReady"
 	WorkloadResourceSubmitted = "ResourcesSubmitted"
+	WorkloadHealthy           = "ResourcesHealthy"
 )
 
 const (
@@ -41,6 +42,7 @@ const (
 const (
 	ConditionResourceReady     = "Ready"
 	ConditionResourceSubmitted = "ResourceSubmitted"
+	ConditionResourceHealthy   = "Healthy"
 )
 
 // +kubebuilder:object:root=true

--- a/pkg/commands/workload_get_test.go
+++ b/pkg/commands/workload_get_test.go
@@ -244,8 +244,7 @@ ready:         False
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 No pods found for workload.
 
@@ -325,8 +324,7 @@ ready:         False
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 Services
 CLAIM      NAME         KIND         API VERSION
@@ -405,8 +403,7 @@ ready:         Unknown
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 No pods found for workload.
 
@@ -443,8 +440,7 @@ ready:         False
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 No pods found for workload.
 
@@ -500,8 +496,7 @@ ready:         False
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 No pods found for workload.
 
@@ -549,8 +544,7 @@ ready:         False
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 No pods found for workload.
 
@@ -594,8 +588,7 @@ ready:         False
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 No pods found for workload.
 
@@ -638,6 +631,8 @@ To see logs: "tanzu apps workload tail my-workload"
 										Status(metav1.ConditionTrue),
 									diecartov1alpha1.WorkloadConditionResourceSubmittedBlank.
 										Status(metav1.ConditionTrue),
+									diecartov1alpha1.WorkloadConditionResourceHealthyBlank.
+										Status(metav1.ConditionTrue),
 								).DieRelease(),
 							diecartov1alpha1.RealizedResourceBlank.
 								Name("deliverable").
@@ -646,6 +641,8 @@ To see logs: "tanzu apps workload tail my-workload"
 										Status(metav1.ConditionUnknown),
 									diecartov1alpha1.WorkloadConditionResourceSubmittedBlank.
 										Status(metav1.ConditionUnknown),
+									diecartov1alpha1.WorkloadConditionResourceHealthyBlank.
+										Status(metav1.ConditionUnknown),
 								).DieRelease(),
 							diecartov1alpha1.RealizedResourceBlank.
 								Name("image-builder").
@@ -653,6 +650,8 @@ To see logs: "tanzu apps workload tail my-workload"
 									diecartov1alpha1.WorkloadConditionResourceReadyBlank.
 										Status(metav1.ConditionFalse),
 									diecartov1alpha1.WorkloadConditionResourceSubmittedBlank.
+										Status(metav1.ConditionFalse),
+									diecartov1alpha1.WorkloadConditionResourceHealthyBlank.
 										Status(metav1.ConditionFalse),
 								).DieRelease(),
 						)
@@ -674,16 +673,102 @@ name:          my-supply-chain
 last update:   <unknown>
 ready:         False
 
-RESOURCE          READY     TIME
-source-provider   True      <unknown>
-deliverable       Unknown   <unknown>
-image-builder     False     <unknown>
+RESOURCE          READY     HEALTHY   TIME
+source-provider   True      True      <unknown>
+deliverable       Unknown   Unknown   <unknown>
+image-builder     False     False     <unknown>
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 No pods found for workload.
+
+To see logs: "tanzu apps workload tail my-workload"
+
+`,
+		}, {
+			Name: "show healthy rule condition issue",
+			Args: []string{workloadName},
+			GivenObjects: []client.Object{
+				parent.
+					StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
+						d.ConditionsDie(
+							diecartov1alpha1.WorkloadConditionReadyBlank.
+								Status(metav1.ConditionUnknown).
+								Reason("OopsieDoodle").
+								Message("a hopefully informative message about what went wrong"),
+							diecartov1alpha1.WorkloadConditionHealthyBlank.
+								Status(metav1.ConditionUnknown).
+								Reason("AnotherOopsieDoodle").
+								Message("a hopefully informative message about what is not healthy"),
+						)
+					}),
+				pod1Die.
+					StatusDie(func(d *diecorev1.PodStatusDie) {
+						d.Phase(corev1.PodRunning)
+					}),
+			},
+			ExpectOutput: `
+---
+# my-workload: Unknown
+---
+Supply Chain
+name:          <none>
+last update:   <unknown>
+ready:         Unknown
+
+Supply Chain resources not found.
+
+Issues
+OopsieDoodle:          a hopefully informative message about what went wrong
+AnotherOopsieDoodle:   a hopefully informative message about what is not healthy
+
+Pods
+NAME   STATUS    RESTARTS   AGE
+pod1   Running   0          2y
+
+To see logs: "tanzu apps workload tail my-workload"
+
+`,
+		}, {
+			Name: "show only ready condition issue",
+			Args: []string{workloadName},
+			GivenObjects: []client.Object{
+				parent.
+					StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
+						d.ConditionsDie(
+							diecartov1alpha1.WorkloadConditionReadyBlank.
+								Status(metav1.ConditionUnknown).
+								Reason("OopsieDoodle").
+								Message("a hopefully informative message about what went wrong"),
+							diecartov1alpha1.WorkloadConditionHealthyBlank.
+								Status(metav1.ConditionUnknown).
+								Reason("OopsieDoodle").
+								Message("a hopefully informative message about what went wrong"),
+						)
+					}),
+				pod1Die.
+					StatusDie(func(d *diecorev1.PodStatusDie) {
+						d.Phase(corev1.PodRunning)
+					}),
+			},
+			ExpectOutput: `
+---
+# my-workload: Unknown
+---
+Supply Chain
+name:          <none>
+last update:   <unknown>
+ready:         Unknown
+
+Supply Chain resources not found.
+
+Issues
+OopsieDoodle:   a hopefully informative message about what went wrong
+
+Pods
+NAME   STATUS    RESTARTS   AGE
+pod1   Running   0          2y
 
 To see logs: "tanzu apps workload tail my-workload"
 
@@ -731,8 +816,7 @@ ready:         Unknown
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 Pods
 NAME   STATUS    RESTARTS   AGE
@@ -789,8 +873,7 @@ ready:         Unknown
 Supply Chain resources not found.
 
 Issues
-reason:    OopsieDoodle
-message:   a hopefully informative message about what went wrong
+OopsieDoodle:   a hopefully informative message about what went wrong
 
 No pods found for workload.
 

--- a/pkg/dies/cartographer/v1alpha1/workload.go
+++ b/pkg/dies/cartographer/v1alpha1/workload.go
@@ -46,8 +46,10 @@ func (d *WorkloadStatusDie) ConditionsDie(conditions ...*diemetav1.ConditionDie)
 
 var (
 	WorkloadConditionReadyBlank             = diemetav1.ConditionBlank.Type(cartov1alpha1.WorkloadConditionReady)
+	WorkloadConditionHealthyBlank           = diemetav1.ConditionBlank.Type(cartov1alpha1.WorkloadHealthy)
 	WorkloadConditionResourceSubmittedBlank = diemetav1.ConditionBlank.Type(cartov1alpha1.ConditionResourceSubmitted)
 	WorkloadConditionResourceReadyBlank     = diemetav1.ConditionBlank.Type(cartov1alpha1.ConditionResourceReady)
+	WorkloadConditionResourceHealthyBlank   = diemetav1.ConditionBlank.Type(cartov1alpha1.ConditionResourceHealthy)
 )
 
 // +die


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Add HEALTHY column to surface the healthy status of each resource in workload get output

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #215 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Unit testing
- Test in local cluster

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Signed-off-by: Wendy Arango warango@vmware.com