### PR TITLE
Adding type to the workload LIST output

### DIFF
--- a/pkg/commands/workload_list.go
+++ b/pkg/commands/workload_list.go
@@ -168,7 +168,8 @@ func (opts *WorkloadListOptions) print(workload *cartov1alpha1.Workload, _ table
 		labels = map[string]string{}
 	}
 
-	row.Cells = append(row.Cells, workload.Name)
+	row.Cells = append(row.Cells, workload.Name,
+		printer.EmptyString(labels[apis.WorkloadTypeLabelName]))
 	if opts.App == "" {
 		row.Cells = append(row.Cells, printer.EmptyString(labels[apis.AppPartOfLabelName]))
 	}
@@ -182,7 +183,8 @@ func (opts *WorkloadListOptions) print(workload *cartov1alpha1.Workload, _ table
 func (opts *WorkloadListOptions) printColumns() []metav1beta1.TableColumnDefinition {
 	cols := []metav1beta1.TableColumnDefinition{}
 
-	cols = append(cols, metav1beta1.TableColumnDefinition{Name: "Name", Type: "string"})
+	cols = append(cols, metav1beta1.TableColumnDefinition{Name: "Name", Type: "string"},
+		metav1beta1.TableColumnDefinition{Name: "Type", Type: "string"})
 	if opts.App == "" {
 		cols = append(cols, metav1beta1.TableColumnDefinition{Name: "App", Type: "string"})
 	}

--- a/pkg/commands/workload_list_test.go
+++ b/pkg/commands/workload_list_test.go
@@ -132,8 +132,8 @@ No workloads found.
 				parent,
 			},
 			ExpectOutput: `
-NAME            APP       READY       AGE
-test-workload   <empty>   <unknown>   2y
+NAME            TYPE      APP       READY       AGE
+test-workload   <empty>   <empty>   <unknown>   2y
 `,
 		},
 		{
@@ -155,6 +155,7 @@ test-workload   <empty>   <unknown>   2y
 						d.Name("my-workload")
 						d.Namespace(defaultNamespace)
 						d.CreationTimestamp(metav1.Date(2021, time.September, 10, 15, 00, 00, 00, time.UTC))
+						d.AddLabel(apis.WorkloadTypeLabelName, "web")
 					}),
 			},
 			ExpectOutput: `
@@ -180,7 +181,10 @@ test-workload   <empty>   <unknown>   2y
 			"name": "my-workload",
 			"namespace": "default",
 			"resourceVersion": "999",
-			"creationTimestamp": "2021-09-10T15:00:00Z"
+			"creationTimestamp": "2021-09-10T15:00:00Z",
+			"labels": {
+				"apps.tanzu.vmware.com/workload-type": "web"
+			}
 		},
 		"spec": {},
 		"status": {
@@ -217,6 +221,7 @@ test-workload   <empty>   <unknown>   2y
 						d.Name("another-workload")
 						d.Namespace(defaultNamespace)
 						d.CreationTimestamp(metav1.Date(2021, time.September, 10, 15, 00, 00, 00, time.UTC))
+						d.AddLabel(apis.WorkloadTypeLabelName, "web")
 					}),
 				diecartov1alpha1.WorkloadBlank.
 					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
@@ -231,6 +236,8 @@ test-workload   <empty>   <unknown>   2y
   kind: Workload
   metadata:
     creationTimestamp: "2021-09-10T15:00:00Z"
+    labels:
+      apps.tanzu.vmware.com/workload-type: web
     name: another-workload
     namespace: default
     resourceVersion: "999"
@@ -266,6 +273,7 @@ test-workload   <empty>   <unknown>   2y
 				parent.
 					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 						d.AddLabel(apis.AppPartOfLabelName, "hello")
+						d.AddLabel(apis.WorkloadTypeLabelName, "web")
 					}).
 					StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
 						d.ConditionsDie(
@@ -274,8 +282,8 @@ test-workload   <empty>   <unknown>   2y
 					},
 					)},
 			ExpectOutput: `
-NAME            APP     READY   AGE
-test-workload   hello   Ready   2y
+NAME            TYPE   APP     READY   AGE
+test-workload   web    hello   Ready   2y
 `,
 		},
 		{
@@ -293,8 +301,8 @@ test-workload   hello   Ready   2y
 					}),
 			},
 			ExpectOutput: `
-NAME            READY       AGE
-test-workload   <unknown>   2y
+NAME            TYPE      READY       AGE
+test-workload   <empty>   <unknown>   2y
 `,
 		},
 		{
@@ -339,12 +347,13 @@ Error: namespace "foo" not found, it may not exist or user does not have permiss
 						d.Name("test-other-workload")
 						d.Namespace(otherNamespace)
 						d.CreationTimestamp(objTimeStamp)
+						d.AddLabel(apis.WorkloadTypeLabelName, "web")
 					}),
 			},
 			ExpectOutput: `
-NAMESPACE         NAME                  APP       READY       AGE
-default           test-workload         <empty>   <unknown>   2y
-other-namespace   test-other-workload   <empty>   <unknown>   2y
+NAMESPACE         NAME                  TYPE      APP       READY       AGE
+default           test-workload         <empty>   <empty>   <unknown>   2y
+other-namespace   test-other-workload   web       <empty>   <unknown>   2y
 `,
 		},
 		{


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it

Modified the workload LIST command output to list the TYPE of the workloads
### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes # 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Modified the workload_list_test.go file to include the test scenarios with TYPE int he results.
Added TYPE label for yaml, json as well with and without values in the test cases.

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Fixed the issue 223 for workload list commands