### PR TITLE
Adding overview in the output for workload get

### DIFF
--- a/pkg/commands/workload_get.go
+++ b/pkg/commands/workload_get.go
@@ -115,7 +115,12 @@ func (opts *WorkloadGetOptions) Exec(ctx context.Context, c *cli.Config) error {
 
 	workloadStatusReadyCond := printer.FindCondition(workload.Status.Conditions, cartov1alpha1.WorkloadConditionReady)
 	c.Printf(printer.ResourceStatus(workload.Name, workloadStatusReadyCond))
-
+	//print workload details
+	c.Boldf("Overview\n")
+	if err := printer.WorkloadOverviewPrinter(c.Stdout, workload); err != nil {
+		return err
+	}
+	c.Printf("\n")
 	// Print workload source
 	if workload.Spec.Image != "" || workload.Spec.Source != nil {
 		c.Boldf("Source\n")

--- a/pkg/printer/workload_overview_printer.go
+++ b/pkg/printer/workload_overview_printer.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer
+
+import (
+	"io"
+
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis"
+	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/printer"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/printer/table"
+)
+
+func WorkloadOverviewPrinter(w io.Writer, workload *cartov1alpha1.Workload) error {
+	printLocalSourceInfo := func(workload *cartov1alpha1.Workload, printOpts table.PrintOptions) ([]metav1beta1.TableRow, error) {
+
+		labels := workload.Labels
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		sourceRow := metav1beta1.TableRow{
+			Cells: []interface{}{
+				"type:",
+				printer.EmptyString(labels[apis.WorkloadTypeLabelName]),
+			},
+		}
+
+		rows := []metav1beta1.TableRow{sourceRow}
+
+		return rows, nil
+	}
+	tablePrinter := table.NewTablePrinter(table.PrintOptions{NoHeaders: true}).With(func(h table.PrintHandler) {
+		h.TableHandler(nil, printLocalSourceInfo)
+	})
+
+	return tablePrinter.PrintObj(workload, w)
+}

--- a/pkg/printer/workload_overview_printer_test.go
+++ b/pkg/printer/workload_overview_printer_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis"
+	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/printer"
+)
+
+func TestWorkloadDetailsPrinter(t *testing.T) {
+	defaultNamespace := "default"
+	workloadName := "my-workload"
+	labels := make(map[string]string)
+	labels[apis.WorkloadTypeLabelName] = "web"
+	tests := []struct {
+		name           string
+		testWorkload   *cartov1alpha1.Workload
+		expectedOutput string
+	}{{
+		name: "type label not present",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Image: "my-image",
+			},
+		},
+		expectedOutput: `
+type:   <empty>
+`,
+	}, {
+		name: "type label present",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+				Labels:    labels,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Image: "my-image",
+			},
+		},
+		expectedOutput: `
+type:   web
+`,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := &bytes.Buffer{}
+			if err := printer.WorkloadOverviewPrinter(output, test.testWorkload); err != nil {
+				t.Errorf("WorkloadSourcePrinter() expected no error, got %v", err)
+			}
+			outputString := output.String()
+			if diff := cmp.Diff(strings.TrimPrefix(test.expectedOutput, "\n"), outputString); diff != "" {
+				t.Errorf("Unexpected output (-expected, +actual): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Modified the workload GET command output to list the TYPE of the workload. The type is listed under Overview section in the output.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes # 223

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Unit test cases updated to validate the new Overview section with the type details. Added unit test cases to validate the over print file.
Test in local cluster

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Fixes the issue 223 for the get command output