### PR TITLE
Display info when there is no change in local source 

### DIFF
--- a/pkg/commands/workload.go
+++ b/pkg/commands/workload.go
@@ -339,7 +339,7 @@ func (opts *WorkloadOptions) ApplyOptionsToWorkload(ctx context.Context, workloa
 // PublishLocalSource packages the specified source code in the --local-path flag and creates an image
 // that will be eventually published to the registry specified in the --source-image flag.
 // Returns a boolean that indicates if user does actually want to publish the image and an error in case of failure
-func (opts *WorkloadOptions) PublishLocalSource(ctx context.Context, c *cli.Config, workload *cartov1alpha1.Workload) (bool, error) {
+func (opts *WorkloadOptions) PublishLocalSource(ctx context.Context, c *cli.Config, currentWorkload, workload *cartov1alpha1.Workload) (bool, error) {
 	if opts.LocalPath == "" {
 		return true, nil
 	}
@@ -381,8 +381,13 @@ func (opts *WorkloadOptions) PublishLocalSource(ctx context.Context, c *cli.Conf
 		return okToPush, err
 	}
 	workload.Spec.Source.Image = digestedImage
-	c.Successf("Published source\n")
 
+	if currentWorkload != nil && currentWorkload.Spec.Source.Image == workload.Spec.Source.Image {
+		c.Infof("No source code is changed\n")
+		return okToPush, nil
+	}
+
+	c.Successf("Published source\n")
 	return okToPush, nil
 }
 

--- a/pkg/commands/workload_apply.go
+++ b/pkg/commands/workload_apply.go
@@ -131,7 +131,7 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 	}
 
 	// If user answers yes to survey prompt about publishing source, continue with creation or update
-	if okToPush, err := opts.PublishLocalSource(ctx, c, workload); err != nil {
+	if okToPush, err := opts.PublishLocalSource(ctx, c, currentWorkload, workload); err != nil {
 		return err
 	} else if !okToPush {
 		return nil

--- a/pkg/commands/workload_create.go
+++ b/pkg/commands/workload_create.go
@@ -108,7 +108,7 @@ func (opts *WorkloadCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	}
 
 	// If user answers yes to survey prompt about publishing source, continue with workload creation
-	if okToPush, err := opts.PublishLocalSource(ctx, c, workload); err != nil {
+	if okToPush, err := opts.PublishLocalSource(ctx, c, nil, workload); err != nil {
 		return err
 	} else if !okToPush {
 		return nil

--- a/pkg/commands/workload_update.go
+++ b/pkg/commands/workload_update.go
@@ -131,7 +131,7 @@ func (opts *WorkloadUpdateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	}
 
 	// If user answers yes to survey prompt about publishing source, continue with workload update
-	if okToPush, err := opts.PublishLocalSource(ctx, c, workload); err != nil {
+	if okToPush, err := opts.PublishLocalSource(ctx, c, currentWorkload, workload); err != nil {
 		return err
 	} else if !okToPush {
 		return nil


### PR DESCRIPTION
Pull request

### What this PR does / why we need it
when the local source hasnt changed, display info `No sourc code is changed`, instead of `Published source`.

### Which issue(s) this PR fixes

Fixes #175 

### Describe testing done for PR

case when no change in code + no change in spec

```
% tanzu apps workload apply pet-img-6 --source-image gcr.io/SOMETHING/petclinictestjar:source --local-path /Users/snagarajared/workspace/spring-petclinic/target/spring-petclinic-2.6.0-SNAPSHOT.jar  
? Publish source in "/Users/snagarajared/workspace/spring-petclinic/target/spring-petclinic-2.6.0-SNAPSHOT.jar" to "gcr.io/SOMETHINGpetclinictestjar:source"? It may be visible to others who can pull images from that repository Yes
Publishing source in "/Users/snagarajared/workspace/spring-petclinic/target/spring-petclinic-2.6.0-SNAPSHOT.jar" to "gcr.io/SOMETHING/petclinictestjar:source"...
No source code is changed
Workload is unchanged, skipping update
```

case when no change in code +  change in spec
```
tanzu apps workload apply pet-img-6 --source-image gcr.io/SOMETHING/petclinictestjar:source --local-path /Users/snagarajared/workspace/spring-petclinic/target/spring-petclinic-2.6.0-SNAPSHOT.jar  --label type=web
? Publish source in "/Users/snagarajared/workspace/spring-petclinic/target/spring-petclinic-2.6.0-SNAPSHOT.jar" to "gcr.io/SOMETHING/petclinictestjar:source"? It may be visible to others who can pull images from that repository Yes
Publishing source in "/Users/snagarajared/workspace/spring-petclinic/target/spring-petclinic-2.6.0-SNAPSHOT.jar" to "gcr.io/SOMETHING/petclinictestjar:source"...
No source code is changed
Update workload:
  1,  1   |---
  2,  2   |apiVersion: carto.run/v1alpha1
  3,  3   |kind: Workload
  4,  4   |metadata:
      5 + |  labels:
      6 + |    type: web
  5,  7   |  name: pet-img-6
  6,  8   |  namespace: default
  7,  9   |spec:
  8, 10   |  source:
...

? Really update the workload "pet-img-6"? Yes
Updated workload "pet-img-6"

To see logs:   "tanzu apps workload tail pet-img-6"
To get status: "tanzu apps workload get pet-img-6"

```

