### PR TITLE
chore: Add color to healthy column

### DIFF
--- a/pkg/cli-runtime/printer/format.go
+++ b/pkg/cli-runtime/printer/format.go
@@ -57,6 +57,17 @@ func ConditionStatus(cond *metav1.Condition) string {
 	}
 }
 
+func ColorConditionStatus(condStatus string) string {
+	switch condStatus {
+	case "True", "true":
+		return Ssuccessf(condStatus)
+	case "False", "false":
+		return Serrorf(condStatus)
+	default:
+		return Sinfof(condStatus)
+	}
+}
+
 func Labels(labelMap map[string]string) string {
 	return EmptyString(labels.Set(labelMap).String())
 }

--- a/pkg/cli-runtime/printer/format_test.go
+++ b/pkg/cli-runtime/printer/format_test.go
@@ -138,6 +138,45 @@ func TestConditionStatus(t *testing.T) {
 	}
 }
 
+func TestColorConditionStatus(t *testing.T) {
+	noColor := color.NoColor
+	color.NoColor = true
+	defer func() { color.NoColor = noColor }()
+
+	tests := []struct {
+		name   string
+		input  string
+		output string
+	}{{
+		name:   "empty",
+		output: "",
+	}, {
+		name:   "status true",
+		input:  "True",
+		output: printer.Ssuccessf("True"),
+	}, {
+		name:   "status false",
+		input:  "False",
+		output: printer.Serrorf("False"),
+	}, {
+		name:   "status unknown",
+		input:  "Unknown",
+		output: printer.Sinfof("Unknown"),
+	}, {
+		name:   "status unknown",
+		input:  "SomeOtherStatus",
+		output: printer.Sinfof("SomeOtherStatus"),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if expected, actual := test.output, printer.ColorConditionStatus(test.input); expected != actual {
+				t.Errorf("Expected formated string to be %q, actually %q", expected, actual)
+			}
+		})
+	}
+}
+
 func TestLabels(t *testing.T) {
 	noColor := color.NoColor
 	color.NoColor = true

--- a/pkg/printer/workload_overview_printer.go
+++ b/pkg/printer/workload_overview_printer.go
@@ -29,7 +29,6 @@ import (
 
 func WorkloadOverviewPrinter(w io.Writer, workload *cartov1alpha1.Workload) error {
 	printLocalSourceInfo := func(workload *cartov1alpha1.Workload, printOpts table.PrintOptions) ([]metav1beta1.TableRow, error) {
-
 		labels := workload.Labels
 		if labels == nil {
 			labels = map[string]string{}

--- a/pkg/printer/workload_status_printer.go
+++ b/pkg/printer/workload_status_printer.go
@@ -35,7 +35,7 @@ func WorkloadResourcesPrinter(w io.Writer, workload *cartov1alpha1.Workload) err
 		var healthy string
 		healthyCond := printer.FindCondition(resource.Conditions, cartov1alpha1.ConditionResourceHealthy)
 		if healthyCond != nil {
-			healthy = string(healthyCond.Status)
+			healthy = printer.ColorConditionStatus(string(healthyCond.Status))
 		}
 
 		ready, elapsedTransitionTime := findConditionReady(resource.Conditions, cartov1alpha1.ConditionResourceReady)


### PR DESCRIPTION
Signed-off-by: Wendy Arango <warango@vmware.com>

Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Add color to `HEALTHY` column in workload get output so it helps users to better visualize and distinguish the status of every step of their workload. 

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #227 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->
Color code is
`true`=green/good
`false`=red/bad
`unknown`=cyan
<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
