### PR TITLE
fix: remove TANZU_APPS_SOURCE_IMAGE from allowed

### DIFF
--- a/docs/working-with-workloads.md
+++ b/docs/working-with-workloads.md
@@ -130,7 +130,6 @@ For this reason the apps plugin support the use some environment variables to se
 - `--registry-password`: `TANZU_APPS_REGISTRY_PASSWORD`
 - `--registry-username`: `TANZU_APPS_REGISTRY_USERNAME`
 - `--registry-token`: `TANZU_APPS_REGISTRY_TOKEN`
-- `--source-image`: `TANZU_APPS_SOURCE_IMAGE`
 
 **Note:** Be aware that when set a supported environment value, each apps plugin command will set the flag with the value on the environment variable value
 

--- a/pkg/flags/env_var.go
+++ b/pkg/flags/env_var.go
@@ -25,7 +25,6 @@ var (
 		FlagToEnvVar(RegistryPasswordFlagName): true,
 		FlagToEnvVar(RegistryTokenFlagName):    true,
 		FlagToEnvVar(RegistryUsernameFlagName): true,
-		FlagToEnvVar(SourceImageFlagName):      true,
 		FlagToEnvVar(TypeFlagName):             true,
 	}
 )

--- a/testing/e2e/workload_test.go
+++ b/testing/e2e/workload_test.go
@@ -199,10 +199,10 @@ func TestCreateFromGitWithAnnotations(t *testing.T) {
 					"workload", "create", "test-create-local-registry-venv",
 					"--local-path=./testdata/hello.go.jar",
 					namespaceFlag,
+					"--source-image", os.Getenv("BUNDLE")+"-env",
 					"--yes",
 				)
 				c.AddEnvVars(
-					"TANZU_APPS_SOURCE_IMAGE="+os.Getenv("BUNDLE")+"-env",
 					"TANZU_APPS_TYPE=web",
 					"TANZU_APPS_REGISTRY_USERNAME="+os.Getenv("REGISTRY_USERNAME"),
 					"TANZU_APPS_REGISTRY_PASSWORD="+os.Getenv("REGISTRY_PASSWORD"),


### PR DESCRIPTION
# Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it

Removes TANZU_APPS_SOURCE_IMAGE environment variable from allowed to use as default

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
