### PR TITLE
Recognize maven type flag

### DIFF
--- a/pkg/apis/cartographer/v1alpha1/workload_helpers.go
+++ b/pkg/apis/cartographer/v1alpha1/workload_helpers.go
@@ -298,6 +298,9 @@ func (w *WorkloadSpec) MergeMavenSource(source MavenSource) {
 		if source.Version != "" {
 			currentMaven.Version = source.Version
 		}
+		if source.Type != nil {
+			currentMaven.Type = source.Type
+		}
 	}
 	w.MergeParams(WorkloadMavenParam, currentMaven)
 }

--- a/pkg/apis/cartographer/v1alpha1/workload_test.go
+++ b/pkg/apis/cartographer/v1alpha1/workload_test.go
@@ -1022,6 +1022,7 @@ func TestWorkloadSpec_RemoveAnnotationParams(t *testing.T) {
 }
 
 func TestWorkloadSpec_MergeMavenSource(t *testing.T) {
+	temp := "jar"
 	tests := []struct {
 		name  string
 		seed  *WorkloadSpec
@@ -1058,6 +1059,23 @@ func TestWorkloadSpec_MergeMavenSource(t *testing.T) {
 			Params: []Param{{
 				Name:  "maven",
 				Value: apiextensionsv1.JSON{Raw: []byte(`{"artifactId":"foo","groupId":"bar","version":"0.1.1"}`)},
+			}},
+		},
+	}, {
+		name: "change maven type",
+		seed: &WorkloadSpec{
+			Params: []Param{{
+				Name:  "maven",
+				Value: apiextensionsv1.JSON{Raw: []byte(`{"version":"0.1.0"}`)},
+			}},
+		},
+		value: MavenSource{
+			Type: &temp,
+		},
+		want: &WorkloadSpec{
+			Params: []Param{{
+				Name:  "maven",
+				Value: apiextensionsv1.JSON{Raw: []byte(`{"artifactId":"","groupId":"","version":"0.1.0","type":"jar"}`)},
 			}},
 		},
 	}, {

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -2720,7 +2720,7 @@ To get status: "tanzu apps workload get my-workload"
 		},
 		{
 			Name: "update workload to add maven through flags",
-			Args: []string{workloadName, flags.MavenArtifactFlagName, "spring-petclinic", flags.MavenVersionFlagName, "2.6.0", flags.MavenGroupFlagName, "org.springframework.samples", flags.YesFlagName},
+			Args: []string{workloadName, flags.MavenArtifactFlagName, "spring-petclinic", flags.MavenVersionFlagName, "2.6.0", flags.MavenGroupFlagName, "org.springframework.samples", flags.MavenTypeFlagName, "jar", flags.YesFlagName},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {}),
@@ -2736,7 +2736,7 @@ To get status: "tanzu apps workload get my-workload"
 						Params: []cartov1alpha1.Param{
 							{
 								Name:  "maven",
-								Value: apiextensionsv1.JSON{Raw: []byte(`{"artifactId":"spring-petclinic","groupId":"org.springframework.samples","version":"2.6.0"}`)},
+								Value: apiextensionsv1.JSON{Raw: []byte(`{"artifactId":"spring-petclinic","groupId":"org.springframework.samples","version":"2.6.0","type":"jar"}`)},
 							},
 						},
 					},
@@ -2756,7 +2756,8 @@ Update workload:
      10 + |    value:
      11 + |      artifactId: spring-petclinic
      12 + |      groupId: org.springframework.samples
-     13 + |      version: 2.6.0
+     13 + |      type: jar
+     14 + |      version: 2.6.0
 
 Updated workload "my-workload"
 
@@ -2767,7 +2768,7 @@ To get status: "tanzu apps workload get my-workload"
 		},
 		{
 			Name: "update workload to change maven info through flags",
-			Args: []string{workloadName, flags.MavenVersionFlagName, "2.6.1", flags.YesFlagName},
+			Args: []string{workloadName, flags.MavenVersionFlagName, "2.6.1", flags.MavenTypeFlagName, "jar", flags.YesFlagName},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
@@ -2788,7 +2789,7 @@ To get status: "tanzu apps workload get my-workload"
 						Params: []cartov1alpha1.Param{
 							{
 								Name:  "maven",
-								Value: apiextensionsv1.JSON{Raw: []byte(`{"artifactId":"spring-petclinic","groupId":"org.springframework.samples","version":"2.6.1"}`)},
+								Value: apiextensionsv1.JSON{Raw: []byte(`{"artifactId":"spring-petclinic","groupId":"org.springframework.samples","version":"2.6.1","type":"jar"}`)},
 							},
 						},
 					},
@@ -2802,7 +2803,8 @@ Update workload:
  11, 11   |      artifactId: spring-petclinic
  12, 12   |      groupId: org.springframework.samples
  13     - |      version: 2.6.0
-     13 + |      version: 2.6.1
+     13 + |      type: jar
+     14 + |      version: 2.6.1
 
 Updated workload "my-workload"
 


### PR DESCRIPTION
### What this PR does / why we need it

When maven `type` flag is passed, update the workload to recognize the flag.

### Which issue(s) this PR fixes

Follow up for fixes #170 
