### PR TITLE
fix: validate namespace when validating workload

### DIFF
--- a/pkg/commands/workload_apply.go
+++ b/pkg/commands/workload_apply.go
@@ -88,11 +88,17 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 	workload := &cartov1alpha1.Workload{}
 	var currentWorkload *cartov1alpha1.Workload
 	err := c.Get(ctx, client.ObjectKey{Namespace: opts.Namespace, Name: opts.Name}, workload)
-	if err != nil && !apierrs.IsNotFound(err) {
-		return err
-	}
 	if err == nil {
 		currentWorkload = workload.DeepCopy()
+	} else {
+		if !apierrs.IsNotFound(err) {
+			return err
+		}
+		if apierrs.IsNotFound(err) {
+			if nsErr := validateNamespace(ctx, c, opts.Namespace); nsErr != nil {
+				return nsErr
+			}
+		}
 	}
 
 	workload.Name = opts.Name

--- a/pkg/commands/workload_create.go
+++ b/pkg/commands/workload_create.go
@@ -75,6 +75,10 @@ func (opts *WorkloadCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		// return err, except when not found
 		if !apierrs.IsNotFound(err) {
 			return err
+		} else if apierrs.IsNotFound(err) {
+			if nsErr := validateNamespace(ctx, c, opts.Namespace); nsErr != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
# Pull request

### What this PR does / why we need it

Validates if the provided namespace can be accessed by the user when validating if workload exists.

### Which issue(s) this PR fixes

Fixes #271 

### Describe testing done for PR

Loca installation of plugin against TAP1.2 cluster in GKE

![image](https://user-images.githubusercontent.com/2386675/186713711-559dba1c-6789-40b5-93fe-57a832ccc99c.png)

Try to create a workload from source code in the default namespace and a non-existing namespace.


### Additional information or special notes for your reviewer

This validation applies to all the `apply`/`create` subcommands, if the namespace does not exist or is not accessible for the user it will throw an error
