### PR TITLE
feat: Moved workload to overview and  remove status

### DIFF
--- a/pkg/commands/workload_get.go
+++ b/pkg/commands/workload_get.go
@@ -113,8 +113,6 @@ func (opts *WorkloadGetOptions) Exec(ctx context.Context, c *cli.Config) error {
 		return nil
 	}
 
-	workloadStatusReadyCond := printer.FindCondition(workload.Status.Conditions, cartov1alpha1.WorkloadConditionReady)
-	c.Printf(printer.ResourceStatus(workload.Name, workloadStatusReadyCond))
 	//print workload details
 	c.Boldf("Overview\n")
 	if err := printer.WorkloadOverviewPrinter(c.Stdout, workload); err != nil {
@@ -199,6 +197,7 @@ func (opts *WorkloadGetOptions) Exec(ctx context.Context, c *cli.Config) error {
 	// Print workload issues
 	c.Printf("\n")
 	c.Boldf("Messages\n")
+	workloadStatusReadyCond := printer.FindCondition(workload.Status.Conditions, cartov1alpha1.WorkloadConditionReady)
 	if areAllResourcesReady(workloadStatusReadyCond, deliverableStatusReadyCond) {
 		c.Infof(printer.AddPaddingStart("No messages found.\n"))
 	} else {

--- a/pkg/commands/workload_get_test.go
+++ b/pkg/commands/workload_get_test.go
@@ -183,10 +183,8 @@ func TestWorkloadGetCommand(t *testing.T) {
 			Args:         []string{workloadName},
 			GivenObjects: []client.Object{parent},
 			ExpectOutput: `
----
-# my-workload: <unknown>
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain reference not found.
@@ -215,10 +213,8 @@ To see logs: "tanzu apps workload tail my-workload"
 				}),
 			},
 			ExpectOutput: `
----
-# my-workload: <unknown>
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain reference not found.
@@ -251,10 +247,8 @@ To see logs: "tanzu apps workload tail my-workload --namespace my-custom-namespa
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -289,10 +283,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: <unknown>
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -341,10 +333,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -400,10 +390,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   web
 
 Supply Chain
@@ -446,10 +434,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Ready
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -491,10 +477,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Ready
----
 Overview
+   name:   my-workload
    type:   web
 
 Supply Chain
@@ -534,10 +518,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Unknown
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -558,7 +540,7 @@ To see logs: "tanzu apps workload tail my-workload"
 
 `,
 		}, {
-			Name: "show issues with unknown status overview type",
+			Name: "show issues",
 			Args: []string{workloadName},
 			GivenObjects: []client.Object{
 				parent.
@@ -580,10 +562,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Unknown
----
 Overview
+   name:   my-workload
    type:   web
 
 Supply Chain
@@ -625,10 +605,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   web
 
 Supply Chain
@@ -679,10 +657,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Source
@@ -743,10 +719,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   web
 
 Source
@@ -802,10 +776,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   web
 
 Source
@@ -851,10 +823,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Source
@@ -944,10 +914,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Source
@@ -1044,10 +1012,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: OopsieDoodle
----
 Overview
+   name:   my-workload
    type:   web
 
 Source
@@ -1099,10 +1065,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Unknown
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -1148,10 +1112,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Unknown
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -1205,10 +1167,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Unknown
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -1267,10 +1227,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Unknown
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -1328,10 +1286,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Ready
----
 Overview
+   name:   my-workload
    type:   web
 
 Supply Chain
@@ -1425,10 +1381,8 @@ Error: namespace "foo" not found, it may not exist or user does not have permiss
 				clitesting.InduceFailure("list", "PodList"),
 			},
 			ExpectOutput: `
----
-# my-workload: <unknown>
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain reference not found.
@@ -1458,10 +1412,8 @@ To see logs: "tanzu apps workload tail my-workload"
 				clitesting.InduceFailure("list", "KnativeServiceList"),
 			},
 			ExpectOutput: `
----
-# my-workload: <unknown>
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain reference not found.
@@ -1710,10 +1662,8 @@ status:
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Unknown
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -1814,10 +1764,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Ready
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -1899,10 +1847,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Ready
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain
@@ -1960,10 +1906,8 @@ To see logs: "tanzu apps workload tail my-workload"
 					}),
 			},
 			ExpectOutput: `
----
-# my-workload: Ready
----
 Overview
+   name:   my-workload
    type:   <empty>
 
 Supply Chain

--- a/pkg/printer/workload_overview_printer.go
+++ b/pkg/printer/workload_overview_printer.go
@@ -33,6 +33,12 @@ func WorkloadOverviewPrinter(w io.Writer, workload *cartov1alpha1.Workload) erro
 		if labels == nil {
 			labels = map[string]string{}
 		}
+		nameRow := metav1beta1.TableRow{
+			Cells: []interface{}{
+				"name:",
+				workload.GetName(),
+			},
+		}
 		sourceRow := metav1beta1.TableRow{
 			Cells: []interface{}{
 				"type:",
@@ -40,7 +46,7 @@ func WorkloadOverviewPrinter(w io.Writer, workload *cartov1alpha1.Workload) erro
 			},
 		}
 
-		rows := []metav1beta1.TableRow{sourceRow}
+		rows := []metav1beta1.TableRow{nameRow, sourceRow}
 
 		return rows, nil
 	}

--- a/pkg/printer/workload_overview_printer_test.go
+++ b/pkg/printer/workload_overview_printer_test.go
@@ -50,6 +50,7 @@ func TestWorkloadDetailsPrinter(t *testing.T) {
 			},
 		},
 		expectedOutput: `
+   name:   my-workload
    type:   <empty>
 `,
 	}, {
@@ -65,6 +66,7 @@ func TestWorkloadDetailsPrinter(t *testing.T) {
 			},
 		},
 		expectedOutput: `
+   name:   my-workload
    type:   web
 `,
 	}}


### PR DESCRIPTION
# Pull request

### What this PR does / why we need it

When `get` a workload the status within the name is shown based on the workload resources but not a combination of workload resources and delivery resources the the status is being removed and the status should be calculated checking the resources.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #278 

### Describe testing done for PR

Getting workloads with local install of the plugin from TAP1.2 cluster on GKE

![image](https://user-images.githubusercontent.com/2386675/186742842-d68dafc2-293c-4f41-8163-621288febd73.png)



### Additional information or special notes for your reviewer
 N/A
