### PR TITLE
fixes Tail output for init container being displayed extra

### DIFF
--- a/pkg/commands/workload_apply.go
+++ b/pkg/commands/workload_apply.go
@@ -183,7 +183,7 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 					panic(err)
 				}
 				containers := []string{}
-				return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Second, opts.TailTimestamps)
+				return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Minute, opts.TailTimestamps)
 			})
 		}
 

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -466,7 +466,7 @@ Workload "my-workload" is ready
 
 				tailer := &logs.FakeTailer{}
 				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
-				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Second, false).Return(nil).Once()
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, false).Return(nil).Once()
 				ctx = logs.StashTailer(ctx, tailer)
 
 				return ctx, nil
@@ -1558,7 +1558,7 @@ Workload "my-workload" is ready
 
 				tailer := &logs.FakeTailer{}
 				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
-				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Second, true).Return(nil).Once()
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, true).Return(nil).Once()
 				ctx = logs.StashTailer(ctx, tailer)
 
 				return ctx, nil

--- a/pkg/commands/workload_create.go
+++ b/pkg/commands/workload_create.go
@@ -150,7 +150,7 @@ func (opts *WorkloadCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 					panic(err)
 				}
 				containers := []string{}
-				return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Second, opts.TailTimestamps)
+				return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Minute, opts.TailTimestamps)
 			})
 		}
 

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -376,7 +376,7 @@ Workload "my-workload" is ready
 
 				tailer := &logs.FakeTailer{}
 				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
-				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Second, false).Return(nil).Once()
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, false).Return(nil).Once()
 				ctx = logs.StashTailer(ctx, tailer)
 
 				return ctx, nil
@@ -455,7 +455,7 @@ Workload "my-workload" is ready
 
 				tailer := &logs.FakeTailer{}
 				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
-				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Second, true).Return(nil).Once()
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, true).Return(nil).Once()
 				ctx = logs.StashTailer(ctx, tailer)
 
 				return ctx, nil

--- a/pkg/commands/workload_tail.go
+++ b/pkg/commands/workload_tail.go
@@ -122,7 +122,7 @@ are displayed. To show historical logs use ` + flags.SinceFlagName + `.
 	cmd.Flags().StringVar(&opts.Component, cli.StripDash(flags.ComponentFlagName), "", "workload component `name` (e.g. build)")
 	cmd.RegisterFlagCompletionFunc(cli.StripDash(flags.ComponentFlagName), completion.SuggestComponentNames(ctx, c))
 	cmd.Flags().BoolVarP(&opts.Timestamps, cli.StripDash(flags.TimestampFlagName), "t", false, "print timestamp for each log line")
-	cmd.Flags().DurationVar(&opts.Since, cli.StripDash(flags.SinceFlagName), time.Second, "time `duration` to start reading logs from")
+	cmd.Flags().DurationVar(&opts.Since, cli.StripDash(flags.SinceFlagName), time.Minute, "time `duration` to start reading logs from")
 	cmd.RegisterFlagCompletionFunc(cli.StripDash(flags.SinceFlagName), completion.SuggestDurationUnits(ctx, completion.CommonDurationUnits))
 	return cmd
 }

--- a/pkg/commands/workload_tail_test.go
+++ b/pkg/commands/workload_tail_test.go
@@ -179,6 +179,31 @@ Workload "default/test-workload" not found
 `,
 		},
 		{
+			Name: "show logs for workload since time being default",
+			Args: []string{flags.NamespaceFlagName, defaultNamespace, workloadName},
+			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
+				tailer := &logs.FakeTailer{}
+				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, false).Return(nil).Once()
+				ctx = logs.StashTailer(ctx, tailer)
+				// simulate a user exit after 10ms
+				ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+				_ = cancel
+				return ctx, nil
+			},
+			CleanUp: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) error {
+				tailer := logs.RetrieveTailer(ctx).(*logs.FakeTailer)
+				tailer.AssertExpectations(t)
+				return nil
+			},
+			GivenObjects: []client.Object{
+				parent,
+			},
+			ExpectOutput: `
+...tail output...
+`,
+		},
+		{
 			Name: "show logs for workload with since time in seconds",
 			Args: []string{flags.NamespaceFlagName, defaultNamespace, flags.SinceFlagName, "1s", workloadName},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {

--- a/pkg/commands/workload_update.go
+++ b/pkg/commands/workload_update.go
@@ -169,7 +169,7 @@ func (opts *WorkloadUpdateOptions) Exec(ctx context.Context, c *cli.Config) erro
 					panic(err)
 				}
 				containers := []string{}
-				return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Second, opts.TailTimestamps)
+				return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Minute, opts.TailTimestamps)
 			})
 		}
 

--- a/pkg/commands/workload_update_test.go
+++ b/pkg/commands/workload_update_test.go
@@ -657,7 +657,7 @@ Workload "my-workload" is ready
 
 				tailer := &logs.FakeTailer{}
 				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
-				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Second, false).Return(nil).Once()
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, false).Return(nil).Once()
 				ctx = logs.StashTailer(ctx, tailer)
 
 				return ctx, nil
@@ -744,7 +744,7 @@ Workload "my-workload" is ready
 
 				tailer := &logs.FakeTailer{}
 				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
-				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Second, true).Return(nil).Once()
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, true).Return(nil).Once()
 				ctx = logs.StashTailer(ctx, tailer)
 
 				return ctx, nil


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
updates the default time for workload tail from 1 second to 1 minute in workload create apply tail or update command. It reduces the number of occurrences of the init container logs being added and removed

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #30 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

updated unit test cases to have tail function use the default value as 1 mint and validated the cli in local cluster as well.
### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
