### PR TITLE
Use `env:` prefix to fetch env vars in windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
     - name: Test
       run: make test
     - name: Build Version
-      run: echo "BUILD_VERSION=${GITHUB_REF/refs\/tags\//}" >> $env:GITHUB_ENV
+      run: echo "BUILD_VERSION=${env:GITHUB_REF/refs\/tags\//}" >> $env:GITHUB_ENV
       if: startsWith(github.ref, 'refs/tags/')
     - name: Build
       run: |


### PR DESCRIPTION
Pull request

### What this PR does / why we need it

Windows runner requires `env:` prefix to get environment variables. 