### PR TITLE
fix: Allow user to pass only git commit for git ref

### DIFF
--- a/pkg/apis/cartographer/v1alpha1/workload_helpers.go
+++ b/pkg/apis/cartographer/v1alpha1/workload_helpers.go
@@ -208,8 +208,8 @@ func (w *GitSource) Validate() validation.FieldErrors {
 		errs = errs.Also(validation.ErrMissingField(flags.GitRepoFlagName))
 	}
 
-	if w.Ref.Branch == "" && w.Ref.Tag == "" {
-		errs = errs.Also(validation.ErrMissingOneOf(flags.GitBranchFlagName, flags.GitTagFlagName))
+	if w.Ref.Branch == "" && w.Ref.Tag == "" && w.Ref.Commit == "" {
+		errs = errs.Also(validation.ErrMissingOneOf(flags.GitBranchFlagName, flags.GitTagFlagName, flags.GitCommitFlagName))
 	}
 
 	return errs
@@ -339,6 +339,12 @@ func (w *WorkloadSpec) MergeGit(git GitSource) {
 		}
 		if w.Source.Git.Ref.Branch == "" {
 			w.Source.Git.Ref.Branch = stash.Git.Ref.Branch
+		}
+		if w.Source.Git.Ref.Tag == "" {
+			w.Source.Git.Ref.Tag = stash.Git.Ref.Tag
+		}
+		if w.Source.Git.Ref.Commit == "" {
+			w.Source.Git.Ref.Commit = stash.Git.Ref.Commit
 		}
 	}
 }

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -3288,7 +3288,66 @@ To see logs:   "tanzu apps workload tail spring-petclinic --timestamp --since 1h
 To get status: "tanzu apps workload get spring-petclinic"
 
 `,
-		}, {
+		},
+		{
+			Name: "update git fields",
+			Args: []string{workloadName, flags.GitBranchFlagName, "accelerator", flags.GitCommitFlagName, "abcd1234", flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					SpecDie(
+						func(d *diecartov1alpha1.WorkloadSpecDie) {
+							d.Source(&cartov1alpha1.Source{
+								Git: &cartov1alpha1.GitSource{
+									URL: "https://github.com/sample-accelerators/spring-petclinic",
+									Ref: cartov1alpha1.GitRef{
+										Branch: "main",
+										Tag:    "tap-1.1",
+									},
+								},
+							})
+						}),
+			},
+			ExpectUpdates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels:    map[string]string{},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: "https://github.com/sample-accelerators/spring-petclinic",
+								Ref: cartov1alpha1.GitRef{
+									Branch: "accelerator",
+									Tag:    "tap-1.1",
+									Commit: "abcd1234",
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+🔎 Update workload:
+...
+  7,  7   |spec:
+  8,  8   |  source:
+  9,  9   |    git:
+ 10, 10   |      ref:
+ 11     - |        branch: main
+     11 + |        branch: accelerator
+     12 + |        commit: abcd1234
+ 12, 13   |        tag: tap-1.1
+ 13, 14   |      url: https://github.com/sample-accelerators/spring-petclinic
+👍 Updated workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`,
+		},
+		{
 			Name: "git source with non-allowed env var",
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				os.Setenv("TANZU_APPS_LABEL", "foo=var")
@@ -5133,7 +5192,9 @@ To get status: "tanzu apps workload get spring-petclinic"
 		},
 		{
 			Name: "update - replace source",
-			Args: []string{flags.FilePathFlagName, "testdata/replace-update-strategy/replace-source.yaml", flags.UpdateStrategyFlagName, "replace", flags.YesFlagName},
+			Args: []string{flags.FilePathFlagName, "testdata/replace-update-strategy/replace-source.yaml",
+				flags.GitCommitFlagName, "efgh456",
+				flags.UpdateStrategyFlagName, "replace", flags.YesFlagName},
 			GivenObjects: []client.Object{
 				parent.
 					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
@@ -5168,7 +5229,7 @@ To get status: "tanzu apps workload get spring-petclinic"
 								URL: "https://github.com/sample-accelerators/spring-petclinic",
 								Ref: cartov1alpha1.GitRef{
 									Tag:    "tap-1.1",
-									Commit: "abcd123",
+									Commit: "efgh456",
 								},
 							},
 						},
@@ -5186,7 +5247,7 @@ To get status: "tanzu apps workload get spring-petclinic"
  13, 13   |      ref:
  14     - |        branch: main
  15     - |      url: https://github.com/spring-projects/spring-petclinic.git
-     14 + |        commit: abcd123
+     14 + |        commit: efgh456
      15 + |        tag: tap-1.1
      16 + |      url: https://github.com/sample-accelerators/spring-petclinic
 👍 Updated workload "spring-petclinic"

--- a/testing/e2e/workload_test.go
+++ b/testing/e2e/workload_test.go
@@ -78,7 +78,6 @@ func TestCreateFromGitWithAnnotations(t *testing.T) {
 				if ctx, err = createPtyTerminal(ctx); err != nil {
 					t.Fatalf("error while opening pty %v", err)
 				}
-
 				return ctx, nil
 			},
 			ExpectedObject: &cartov1alpha1.Workload{
@@ -207,6 +206,43 @@ func TestCreateFromGitWithAnnotations(t *testing.T) {
 							URL: "https://github.com/sample-accelerators/spring-petclinic",
 							Ref: cartov1alpha1.GitRef{
 								Tag: "tap-1.2",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:         "Create workload from repo using git commit",
+			WorkloadName: "test-create-git-commit-workload",
+			Command: func() it.CommandLine {
+				c := *it.NewTanzuAppsCommandLine(
+					"workload", "apply", "test-create-git-commit-workload",
+					"--app=test-create-git-commit-workload",
+					"--git-commit=425ae9a",
+					"--git-repo=https://github.com/sample-accelerators/spring-petclinic",
+					namespaceFlag,
+					"--type=web",
+				)
+				c.SurveyAnswer("y")
+				return c
+			}(),
+			ExpectedObject: &cartov1alpha1.Workload{
+				TypeMeta: workloadTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-create-git-commit-workload",
+					Namespace: it.TestingNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/part-of":           "test-create-git-commit-workload",
+						"apps.tanzu.vmware.com/workload-type": "web",
+					},
+				},
+				Spec: cartov1alpha1.WorkloadSpec{
+					Source: &cartov1alpha1.Source{
+						Git: &cartov1alpha1.GitSource{
+							URL: "https://github.com/sample-accelerators/spring-petclinic",
+							Ref: cartov1alpha1.GitRef{
+								Commit: "425ae9a",
 							},
 						},
 					},
@@ -660,7 +696,10 @@ func TestCreateFromGitWithAnnotations(t *testing.T) {
 			Name:         "Update the created workload",
 			WorkloadName: "test-create-git-annotations-workload",
 			Command: *it.NewTanzuAppsCommandLine(
-				"workload", "apply", "test-create-git-annotations-workload", namespaceFlag, "--annotation=min-instances=3", "--annotation=max-instances=5", "-y"),
+				"workload", "apply", "test-create-git-annotations-workload", namespaceFlag,
+				"--annotation=min-instances=3", "--annotation=max-instances=5",
+				"--git-commit", "425ae9a",
+				"-y"),
 			ExpectedObject: &cartov1alpha1.Workload{
 				TypeMeta: workloadTypeMeta,
 				ObjectMeta: metav1.ObjectMeta{
@@ -682,7 +721,8 @@ func TestCreateFromGitWithAnnotations(t *testing.T) {
 						Git: &cartov1alpha1.GitSource{
 							URL: "https://github.com/sample-accelerators/spring-petclinic",
 							Ref: cartov1alpha1.GitRef{
-								Tag: "tap-1.2",
+								Tag:    "tap-1.2",
+								Commit: "425ae9a",
 							},
 						},
 					},


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Because of a [FluxCD bug](https://github.com/fluxcd/source-controller/issues/315), apps plugin would not allow users to pass a git commit to take the source from when creating a workload, so there was always a need to specify either `--git-branch` or `--git-tag`. There is an [upstream fix](https://github.com/fluxcd/source-controller/pull/462) in the newer versions of FluxCD and TAP has been updated to use the latest (`v0.17.1+`), so apps plugin can also be updated to allow users to create their workload using only `--git-commit`

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #179 
Fixes #28 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Created workloads in cluster using the three flags (`--git-commit`, `--git-tag`, `--git-branch`), each separated, and combination of these. 
- Added/updated unit testing
- Updated e2e test

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Signed-off-by: Wendy Arango <warango@vmware.com>