### PR TITLE
Do not delete subpath when there are updates to source spec

### DIFF
--- a/pkg/apis/cartographer/v1alpha1/workload_helpers.go
+++ b/pkg/apis/cartographer/v1alpha1/workload_helpers.go
@@ -333,6 +333,7 @@ func (w *WorkloadSpec) MergeGit(git GitSource) {
 		Git: &git,
 	}
 	if stash != nil && stash.Git != nil {
+		w.Source.Subpath = stash.Subpath
 		if w.Source.Git.URL == "" {
 			w.Source.Git.URL = stash.Git.URL
 		}
@@ -343,10 +344,14 @@ func (w *WorkloadSpec) MergeGit(git GitSource) {
 }
 
 func (w *WorkloadSpec) MergeSourceImage(image string) {
+	stash := w.Source
 	w.ResetSource()
 
 	w.Source = &Source{
 		Image: image,
+	}
+	if stash != nil && stash.Image != "" {
+		w.Source.Subpath = stash.Subpath
 	}
 }
 

--- a/pkg/apis/cartographer/v1alpha1/workload_test.go
+++ b/pkg/apis/cartographer/v1alpha1/workload_test.go
@@ -1459,6 +1459,59 @@ func TestWorkloadSpec_MergeGit(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "update git source without deleting subpath",
+		seed: &WorkloadSpec{
+			Source: &Source{
+				Git: &GitSource{
+					URL: "git@github.com:example/repo.git",
+					Ref: GitRef{
+						Tag: "v1.0.0",
+					},
+				},
+				Subpath: "my-subpath",
+			},
+		},
+		git: GitSource{
+			Ref: GitRef{
+				Branch: "main",
+			},
+		},
+		want: &WorkloadSpec{
+			Source: &Source{
+				Git: &GitSource{
+					URL: "git@github.com:example/repo.git",
+					Ref: GitRef{
+						Branch: "main",
+					},
+				},
+				Subpath: "my-subpath",
+			},
+		},
+	}, {
+		name: "update to git source deleting subpath",
+		seed: &WorkloadSpec{
+			Source: &Source{
+				Image:   "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+				Subpath: "my-subpath",
+			},
+		},
+		git: GitSource{
+			URL: "git@github.com:example/repo.git",
+			Ref: GitRef{
+				Branch: "main",
+			},
+		},
+		want: &WorkloadSpec{
+			Source: &Source{
+				Git: &GitSource{
+					URL: "git@github.com:example/repo.git",
+					Ref: GitRef{
+						Branch: "main",
+					},
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {
@@ -1467,6 +1520,101 @@ func TestWorkloadSpec_MergeGit(t *testing.T) {
 			got.MergeGit(test.git)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("MergeGit() (-want, +got) = %v", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadSpec_MergeSourceImage(t *testing.T) {
+	tests := []struct {
+		name        string
+		seed        *WorkloadSpec
+		sourceImage string
+		want        *WorkloadSpec
+	}{{
+		name: "set",
+		seed: &WorkloadSpec{
+			Source: &Source{},
+		},
+		sourceImage: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+		want: &WorkloadSpec{
+			Source: &Source{
+				Image: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+			},
+		},
+	}, {
+		name: "update",
+		seed: &WorkloadSpec{
+			Source: &Source{
+				Image: "my-registry.nip.io/my-folder/my-old-image:latest@sha:my-sha1234567890",
+			},
+		},
+		sourceImage: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+		want: &WorkloadSpec{
+			Source: &Source{
+				Image: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+			},
+		},
+	}, {
+		name: "change",
+		seed: &WorkloadSpec{
+			Source: &Source{
+				Git: &GitSource{
+					URL: "git@github.com:example/repo.git",
+					Ref: GitRef{
+						Tag: "v1.0.0",
+					},
+				},
+			},
+		},
+		sourceImage: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+		want: &WorkloadSpec{
+			Source: &Source{
+				Image: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+			},
+		},
+	}, {
+		name: "update without deleting subpath",
+		seed: &WorkloadSpec{
+			Source: &Source{
+				Image:   "my-registry.nip.io/my-folder/my-old-image:latest@sha:my-sha1234567890",
+				Subpath: "my-subpath",
+			},
+		},
+		sourceImage: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+		want: &WorkloadSpec{
+			Source: &Source{
+				Image:   "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+				Subpath: "my-subpath",
+			},
+		},
+	}, {
+		name: "update deleting subpath",
+		seed: &WorkloadSpec{
+			Source: &Source{
+				Git: &GitSource{
+					URL: "git@github.com:example/repo.git",
+					Ref: GitRef{
+						Branch: "main",
+					},
+				},
+				Subpath: "my-subpath",
+			},
+		},
+		sourceImage: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+		want: &WorkloadSpec{
+			Source: &Source{
+				Image: "my-registry.nip.io/my-folder/my-image:latest@sha:my-sha1234567890",
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.seed
+			got.MergeSourceImage(test.sourceImage)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("MergeImage() (-want, +got) = %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION

Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Avoid deleteting subpath when there is an update to other source specifications, as source image or git reference. 

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #431 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Created/updated various workloads with different source specifications 
- Added unit testing 

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->
In the GitHub issue, there was a description relating this error to Git references, but it happens to be also affecting source image specification, so whenever the image was updated, if there was a subpath, was being deleted in the process. 
This PR also addresses and corrects this behaviour.

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Signed-off-by: Wendy Arango <warango@vmware.com>