### PR TITLE
Add --output flag to create/apply

### DIFF
--- a/docs/command-reference/tanzu_apps_workload_apply.md
+++ b/docs/command-reference/tanzu_apps_workload_apply.md
@@ -48,6 +48,7 @@ tanzu apps workload apply --file workload.yaml
       --maven-type string              maven packaging type, defaults to jar
       --maven-version string           version number of maven artifact
   -n, --namespace name                 kubernetes namespace (defaulted from kube config)
+  -o, --output string                  output the Workload formatted. Supported formats: "json", "yaml", "yml"
   -p, --param "key=value" pair         additional parameters represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
       --param-yaml "key=value" pair    specify nested parameters using YAML or JSON formatted values represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
       --registry-ca-cert stringArray   file path to CA certificate used to authenticate with registry, flag can be used multiple times

--- a/docs/command-reference/tanzu_apps_workload_create.md
+++ b/docs/command-reference/tanzu_apps_workload_create.md
@@ -50,6 +50,7 @@ tanzu apps workload create --file workload.yaml
       --maven-type string              maven packaging type, defaults to jar
       --maven-version string           version number of maven artifact
   -n, --namespace name                 kubernetes namespace (defaulted from kube config)
+  -o, --output string                  output the Workload formatted. Supported formats: "json", "yaml", "yml"
   -p, --param "key=value" pair         additional parameters represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
       --param-yaml "key=value" pair    specify nested parameters using YAML or JSON formatted values represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
       --registry-ca-cert stringArray   file path to CA certificate used to authenticate with registry, flag can be used multiple times

--- a/docs/command-reference/tanzu_apps_workload_update.md
+++ b/docs/command-reference/tanzu_apps_workload_update.md
@@ -52,6 +52,7 @@ tanzu apps workload update --file workload.yaml
       --maven-type string              maven packaging type, defaults to jar
       --maven-version string           version number of maven artifact
   -n, --namespace name                 kubernetes namespace (defaulted from kube config)
+  -o, --output string                  output the Workload formatted. Supported formats: "json", "yaml", "yml"
   -p, --param "key=value" pair         additional parameters represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
       --param-yaml "key=value" pair    specify nested parameters using YAML or JSON formatted values represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
       --registry-ca-cert stringArray   file path to CA certificate used to authenticate with registry, flag can be used multiple times

--- a/pkg/cli-runtime/config.go
+++ b/pkg/cli-runtime/config.go
@@ -120,6 +120,18 @@ func (c *Config) Eboldf(format string, a ...interface{}) (n int, err error) {
 	return printer.BoldColor.Fprintf(c.Stderr, format, a...)
 }
 
+func PrintPrompt(shouldPrint bool, printer func(string, ...interface{}) (int, error), format string, a ...interface{}) {
+	if shouldPrint {
+		printer(format, a...)
+	}
+}
+
+func PrintPromptWithEmoji(shouldPrint bool, printer func(Icon, string, ...interface{}) (int, error), icon Icon, format string, a ...interface{}) {
+	if shouldPrint {
+		printer(icon, format, a...)
+	}
+}
+
 func Initialize(name string, scheme *runtime.Scheme) *Config {
 	c := NewDefaultConfig(name, scheme)
 

--- a/pkg/cli-runtime/config_test.go
+++ b/pkg/cli-runtime/config_test.go
@@ -198,3 +198,219 @@ func TestConfig_Emoji(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_PrintPromptWithEmoji(t *testing.T) {
+	scheme := runtime.NewScheme()
+	config := cli.NewDefaultConfig("test", scheme)
+
+	tests := []struct {
+		name        string
+		icon        cli.Icon
+		shouldPrint bool
+		input       string
+		output      string
+	}{{
+		name:        "Text with emoji",
+		shouldPrint: true,
+		icon:        cli.FloppyDisk,
+		input:       "Source",
+		output:      `💾 Source`,
+	}, {
+		name:  "Do not print emoji",
+		icon:  cli.FloppyDisk,
+		input: `Source`,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			config.Stdout = stdout
+			config.Stderr = stderr
+
+			cli.PrintPromptWithEmoji(test.shouldPrint, config.Emoji, test.icon, test.input)
+			if expected, actual := test.output, stdout.String(); expected != actual {
+				t.Errorf("Expected stdout to be %q, actually %q", expected, actual)
+			}
+		})
+	}
+}
+
+func TestConfig_PrintPrompt(t *testing.T) {
+	noColor := color.NoColor
+	color.NoColor = false
+	defer func() { color.NoColor = noColor }()
+
+	scheme := runtime.NewScheme()
+	config := cli.NewDefaultConfig("test", scheme)
+
+	tests := []struct {
+		name        string
+		format      string
+		shouldPrint bool
+		args        []interface{}
+		printer     func(format string, a ...interface{}) (n int, err error)
+		stdout      string
+		stderr      string
+	}{{
+		name:        "Printf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Printf,
+		stdout:      "hello",
+	}, {
+		name:        "Eprintf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Eprintf,
+		stderr:      "hello",
+	}, {
+		name:        "Infof",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Infof,
+		stdout:      printer.InfoColor.Sprint("hello"),
+	}, {
+		name:        "Einfof",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Einfof,
+		stderr:      printer.InfoColor.Sprint("hello"),
+	}, {
+		name:        "Successf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Successf,
+		stdout:      printer.SuccessColor.Sprint("hello"),
+	}, {
+		name:        "Esuccessf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Esuccessf,
+		stderr:      printer.SuccessColor.Sprint("hello"),
+	}, {
+		name:        "Faintf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Faintf,
+		stdout:      printer.FaintColor.Sprint("hello"),
+	}, {
+		name:        "Efaintf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Efaintf,
+		stderr:      printer.FaintColor.Sprint("hello"),
+	}, {
+		name:        "Errorf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Errorf,
+		stdout:      printer.ErrorColor.Sprint("hello"),
+	}, {
+		name:        "Eerrorf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Eerrorf,
+		stderr:      printer.ErrorColor.Sprint("hello"),
+	}, {
+		name:        "Boldf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Boldf,
+		stdout:      printer.BoldColor.Sprint("hello"),
+	}, {
+		name:        "Eboldf",
+		shouldPrint: true,
+		format:      "%s",
+		args:        []interface{}{"hello"},
+		printer:     config.Eboldf,
+		stderr:      printer.BoldColor.Sprint("hello"),
+	}, {
+		name:    "Printf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Printf,
+	}, {
+		name:    "Eprintf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Eprintf,
+	}, {
+		name:    "Infof",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Infof,
+	}, {
+		name:    "Einfof",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Einfof,
+	}, {
+		name:    "Successf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Successf,
+	}, {
+		name:    "Esuccessf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Esuccessf,
+	}, {
+		name:    "Faintf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Faintf,
+	}, {
+		name:    "Efaintf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Efaintf,
+	}, {
+		name:    "Errorf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Errorf,
+	}, {
+		name:    "Eerrorf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Eerrorf,
+	}, {
+		name:    "Boldf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Boldf,
+	}, {
+		name:    "Eboldf",
+		format:  "%s",
+		args:    []interface{}{"hello"},
+		printer: config.Eboldf,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			config.Stdout = stdout
+			config.Stderr = stderr
+
+			cli.PrintPrompt(test.shouldPrint, test.printer, test.format, test.args...)
+			if expected, actual := test.stdout, stdout.String(); expected != actual {
+				t.Errorf("Expected stdout to be %q, actually %q", expected, actual)
+			}
+			if expected, actual := test.stderr, stderr.String(); expected != actual {
+				t.Errorf("Expected stderr to be %q, actually %q", expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -349,6 +349,7 @@ To get status: "tanzu apps workload get my-workload"
 
 Waiting for workload "my-workload" to become ready...
 Workload "my-workload" is ready
+
 `,
 		},
 		{
@@ -428,6 +429,7 @@ To get status: "tanzu apps workload get my-workload"
 Waiting for workload "my-workload" to become ready...
 ...tail output...
 Workload "my-workload" is ready
+
 `,
 		},
 		{
@@ -507,6 +509,7 @@ To get status: "tanzu apps workload get my-workload"
 Waiting for workload "my-workload" to become ready...
 ...tail output...
 Workload "my-workload" is ready
+
 `,
 		},
 		{

--- a/pkg/commands/workload_update.go
+++ b/pkg/commands/workload_update.go
@@ -131,7 +131,7 @@ func (opts *WorkloadUpdateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	}
 
 	// If user answers yes to survey prompt about publishing source, continue with workload update
-	if okToPush, err := opts.PublishLocalSource(ctx, c, currentWorkload, workload); err != nil {
+	if okToPush, err := opts.PublishLocalSource(ctx, c, currentWorkload, workload, true); err != nil {
 		return err
 	} else if !okToPush {
 		return nil


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Add `--output` flag to create/apply to retrieve workload once it's ready (mostly for scripting purposes)

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #392 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Signed-off-by: Wendy Arango <warango@vmware.com>