### PR TITLE
feat: Add git revision in workload get

### DIFF
--- a/pkg/apis/cartographer/v1alpha1/workload.go
+++ b/pkg/apis/cartographer/v1alpha1/workload.go
@@ -46,6 +46,13 @@ const (
 	ConditionResourceHealthy   = "Healthy"
 )
 
+const (
+	ResourceOutputUrl      = "url"
+	ResourceOutputRevision = "revision"
+	ResourceOutputImage    = "image"
+	ResourceOutputConfig   = "config"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories="all"
 // +kubebuilder:subresource:status

--- a/pkg/commands/workload_get_test.go
+++ b/pkg/commands/workload_get_test.go
@@ -649,7 +649,6 @@ To see logs: "tanzu apps workload tail my-workload --timestamp --since 1h"
 								Ref: cartov1alpha1.GitRef{
 									Branch: "main",
 									Tag:    "v1.0.0",
-									Commit: "abcdef",
 								},
 							},
 						})
@@ -665,6 +664,22 @@ To see logs: "tanzu apps workload tail my-workload --timestamp --since 1h"
 							Name:       "my-supply-chain",
 							Namespace:  defaultNamespace,
 						})
+						d.Resources(
+							diecartov1alpha1.RealizedResourceBlank.
+								Name("source-provider").
+								Outputs(cartov1alpha1.Output{
+									Name:    "revision",
+									Preview: "main/abcdef",
+								}).
+								ConditionsDie(
+									diecartov1alpha1.WorkloadConditionResourceReadyBlank.
+										Status(metav1.ConditionTrue),
+									diecartov1alpha1.WorkloadConditionResourceSubmittedBlank.
+										Status(metav1.ConditionTrue),
+									diecartov1alpha1.WorkloadConditionResourceHealthyBlank.
+										Status(metav1.ConditionTrue),
+								).DieRelease(),
+						)
 					}),
 			},
 			ExpectOutput: `
@@ -674,16 +689,17 @@ To see logs: "tanzu apps workload tail my-workload --timestamp --since 1h"
    namespace:   default
 
 💾 Source
-   type:     git
-   url:      https://example.com
-   branch:   main
-   tag:      v1.0.0
-   commit:   abcdef
+   type:       git
+   url:        https://example.com
+   branch:     main
+   tag:        v1.0.0
+   revision:   main/abcdef
 
 📦 Supply Chain
    name:   my-supply-chain
 
-   Supply Chain resources not found.
+   NAME              READY   HEALTHY   UPDATED     RESOURCE
+   source-provider   True    True      <unknown>   not found
 
 🚚 Delivery
 
@@ -894,6 +910,10 @@ To see logs: "tanzu apps workload tail my-workload --timestamp --since 1h"
 						d.Resources(
 							diecartov1alpha1.RealizedResourceBlank.
 								Name("source-provider").
+								Outputs(cartov1alpha1.Output{
+									Name:    "revision",
+									Preview: "main/abcdef",
+								}).
 								ConditionsDie(
 									diecartov1alpha1.WorkloadConditionResourceReadyBlank.
 										Status(metav1.ConditionTrue),
@@ -971,6 +991,7 @@ To see logs: "tanzu apps workload tail my-workload --timestamp --since 1h"
 					}).
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
 						d.Source(&cartov1alpha1.Source{
+							Subpath: "my-subpath",
 							Git: &cartov1alpha1.GitSource{
 								URL: url,
 								Ref: cartov1alpha1.GitRef{
@@ -1040,11 +1061,12 @@ To see logs: "tanzu apps workload tail my-workload --timestamp --since 1h"
    namespace:   default
 
 💾 Source
-   type:     git
-   url:      https://example.com
-   branch:   main
-   tag:      v1.0.0
-   commit:   abcdef
+   type:       git
+   url:        https://example.com
+   branch:     main
+   tag:        v1.0.0
+   sub-path:   my-subpath
+   commit:     abcdef
 
 📦 Supply Chain
    name:   my-supply-chain

--- a/pkg/printer/workload_source_printer_test.go
+++ b/pkg/printer/workload_source_printer_test.go
@@ -140,9 +140,9 @@ func TestWorkloadSourceGitPrinter(t *testing.T) {
 		expectedOutput: `
    type:       git
    url:        https://example.com/my-repo
-   sub-path:   my-subpath
    branch:     my-branch
    tag:        my-tag
+   sub-path:   my-subpath
    commit:     my-commit
 `,
 	}, {
@@ -167,6 +167,158 @@ func TestWorkloadSourceGitPrinter(t *testing.T) {
    type:     git
    url:      https://example.com/my-repo
    branch:   my-branch
+`,
+	}, {
+		name: "built from git with revision",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Source: &cartov1alpha1.Source{
+					Subpath: "my-subpath",
+					Git: &cartov1alpha1.GitSource{
+						URL: "https://example.com/my-repo",
+						Ref: cartov1alpha1.GitRef{
+							Branch: "my-branch",
+							Tag:    "my-tag",
+						},
+					},
+				},
+			},
+			Status: cartov1alpha1.WorkloadStatus{
+				Resources: []cartov1alpha1.RealizedResource{
+					{
+						Outputs: []cartov1alpha1.Output{
+							{
+								Name:    "revision",
+								Preview: "my-branch/my-commit",
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedOutput: `
+   type:       git
+   url:        https://example.com/my-repo
+   branch:     my-branch
+   tag:        my-tag
+   sub-path:   my-subpath
+   revision:   my-branch/my-commit
+`,
+	}, {
+		name: "do not display revision if there is commit",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Source: &cartov1alpha1.Source{
+					Subpath: "my-subpath",
+					Git: &cartov1alpha1.GitSource{
+						URL: "https://example.com/my-repo",
+						Ref: cartov1alpha1.GitRef{
+							Branch: "my-branch",
+							Tag:    "my-tag",
+							Commit: "my-commit",
+						},
+					},
+				},
+			},
+			Status: cartov1alpha1.WorkloadStatus{
+				Resources: []cartov1alpha1.RealizedResource{
+					{
+						Outputs: []cartov1alpha1.Output{
+							{
+								Name:    "revision",
+								Preview: "my-branch/my-commit",
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedOutput: `
+   type:       git
+   url:        https://example.com/my-repo
+   branch:     my-branch
+   tag:        my-tag
+   sub-path:   my-subpath
+   commit:     my-commit
+`,
+	}, {
+		name: "output with no revision",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Source: &cartov1alpha1.Source{
+					Subpath: "my-subpath",
+					Git: &cartov1alpha1.GitSource{
+						URL: "https://example.com/my-repo",
+						Ref: cartov1alpha1.GitRef{
+							Branch: "my-branch",
+							Tag:    "my-tag",
+							Commit: "my-commit",
+						},
+					},
+				},
+			},
+			Status: cartov1alpha1.WorkloadStatus{
+				Resources: []cartov1alpha1.RealizedResource{
+					{
+						Outputs: []cartov1alpha1.Output{
+							{
+								Name:    "url",
+								Preview: "my-source-controller/my-url@sha:mysha12345",
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedOutput: `
+   type:       git
+   url:        https://example.com/my-repo
+   branch:     my-branch
+   tag:        my-tag
+   sub-path:   my-subpath
+   commit:     my-commit
+`,
+	}, {
+		name: "empty status",
+		testWorkload: &cartov1alpha1.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadName,
+				Namespace: defaultNamespace,
+			},
+			Spec: cartov1alpha1.WorkloadSpec{
+				Source: &cartov1alpha1.Source{
+					Subpath: "my-subpath",
+					Git: &cartov1alpha1.GitSource{
+						URL: "https://example.com/my-repo",
+						Ref: cartov1alpha1.GitRef{
+							Branch: "my-branch",
+							Tag:    "my-tag",
+							Commit: "my-commit",
+						},
+					},
+				},
+			},
+			Status: cartov1alpha1.WorkloadStatus{},
+		},
+		expectedOutput: `
+   type:       git
+   url:        https://example.com/my-repo
+   branch:     my-branch
+   tag:        my-tag
+   sub-path:   my-subpath
+   commit:     my-commit
 `,
 	}}
 


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Add git revision to `workload get` so users can know which revision their workload checked out to.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #428 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Added unit test
- Created different workloads with `--git-commit`, `--git-branch` and/or `--git-tag` to check the `workload get` behaviour after retrieving the workload.

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->
From issue description:

> 1. add a `revision` name/value pair to the `Source` section of `tanzu apps workload get` 
>     * in the event the user has passed in the specific commit sha, the `revision` shouldn't be added to the `source` section because that information will be redundant with what's already there
> 2. in the case where sub-path and branch are provided, re-order the location of the branch so the source name/value pairs are ordered by increasing level of specificity (type, url, branch, sub-path, revision)

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
