### PR TITLE
Do not wait for workload to be ready when using --output flag

### DIFF
--- a/pkg/cli-runtime/printer/resource.go
+++ b/pkg/cli-runtime/printer/resource.go
@@ -96,7 +96,14 @@ func OutputResource(obj Object, format OutputFormat, scheme *runtime.Scheme) (st
 	if err != nil {
 		return "", err
 	}
-	return printObject(copy, format)
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(copy)
+	if err != nil {
+		return "", err
+	}
+
+	unstructured.RemoveNestedField(u, "metadata", "managedFields")
+
+	return printObject(u, format)
 }
 
 func OutputResources(objList []Object, format OutputFormat, scheme *runtime.Scheme) (string, error) {

--- a/pkg/cli-runtime/printer/resource_test.go
+++ b/pkg/cli-runtime/printer/resource_test.go
@@ -325,8 +325,6 @@ metadata:
   generation: 1
   labels:
     name: value
-  managedFields:
-  - manager: tanzu
   name: my-workload
   namespace: default
   ownerReferences:
@@ -395,24 +393,24 @@ status:
 		},
 		want: `
 {
-	"kind": "Workload",
 	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
 	"metadata": {
-		"name": "my-workload",
-		"namespace": "default",
-		"selfLink": "/default/my-workload",
-		"uid": "uid-xyz",
-		"resourceVersion": "999",
-		"generation": 1,
-		"creationTimestamp": "2021-09-10T15:00:00Z",
-		"deletionTimestamp": "2021-09-10T15:00:00Z",
-		"deletionGracePeriodSeconds": 5,
-		"labels": {
-			"name": "value"
-		},
 		"annotations": {
 			"name": "value"
 		},
+		"creationTimestamp": "2021-09-10T15:00:00Z",
+		"deletionGracePeriodSeconds": 5,
+		"deletionTimestamp": "2021-09-10T15:00:00Z",
+		"finalizers": [
+			"my.finalizer"
+		],
+		"generation": 1,
+		"labels": {
+			"name": "value"
+		},
+		"name": "my-workload",
+		"namespace": "default",
 		"ownerReferences": [
 			{
 				"apiVersion": "v1",
@@ -421,24 +419,19 @@ status:
 				"uid": ""
 			}
 		],
-		"finalizers": [
-			"my.finalizer"
-		],
-		"managedFields": [
-			{
-				"manager": "tanzu"
-			}
-		]
+		"resourceVersion": "999",
+		"selfLink": "/default/my-workload",
+		"uid": "uid-xyz"
 	},
 	"spec": {},
 	"status": {
 		"conditions": [
 			{
-				"type": "Ready",
-				"status": "True",
 				"lastTransitionTime": "2019-06-29T01:44:05Z",
+				"message": "a hopefully informative message about what went wrong",
 				"reason": "No printing status",
-				"message": "a hopefully informative message about what went wrong"
+				"status": "True",
+				"type": "Ready"
 			}
 		],
 		"supplyChainRef": {}

--- a/pkg/commands/workload.go
+++ b/pkg/commands/workload.go
@@ -795,25 +795,12 @@ func (opts *WorkloadOptions) WaitToBeReady(c *cli.Config, workload *cartov1alpha
 		func(ctx context.Context) error {
 			clientWithWatch, err := watch.GetWatcher(ctx, c)
 			if err != nil {
-				panic(err)
+				return err
 			}
 			return wait.UntilCondition(ctx, clientWithWatch, types.NamespacedName{Name: workload.Name, Namespace: workload.Namespace}, &cartov1alpha1.WorkloadList{}, cartov1alpha1.WorkloadReadyConditionFunc)
 		},
 	}
 	return workers
-}
-
-func (opts *WorkloadOptions) WaitError(ctx context.Context, c *cli.Config, workload *cartov1alpha1.Workload, workers []wait.Worker) error {
-	if err := wait.Race(ctx, opts.WaitTimeout, workers); err != nil {
-		if err == context.DeadlineExceeded {
-			c.Printf("%s timeout after %s waiting for %q to become ready\n", printer.Serrorf("Error:"), opts.WaitTimeout, workload.Name)
-			return cli.SilenceError(err)
-		}
-		c.Eprintf("%s %s\n", printer.Serrorf("Error:"), err)
-		return cli.SilenceError(err)
-	}
-
-	return nil
 }
 
 func (opts *WorkloadOptions) DefineFlags(ctx context.Context, c *cli.Config, cmd *cobra.Command) {

--- a/pkg/commands/workload_apply.go
+++ b/pkg/commands/workload_apply.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/wait"
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/completion"
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/flags"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/printer"
 )
 
 type WorkloadApplyOptions struct {
@@ -187,7 +188,7 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 		}
 	} else if opts.Output != "" && opts.Yes {
 		// since there are no prompts, set okToApply to true (accepted through --yes)
-		okToApply = true
+		okToApply = opts.Yes
 		if !workloadExists {
 			if err := c.Create(ctx, workload); err != nil {
 				return err
@@ -199,45 +200,55 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 		}
 	}
 
-	var workers []wait.Worker
-	if opts.Output != "" && okToApply {
-		workers = opts.WaitToBeReady(c, workload)
-		if err := opts.WaitError(ctx, c, workload, workers); err != nil {
-			return err
-		}
-		// once the workload is ready, get it as is in the cluster
-		if err := c.Get(ctx, client.ObjectKey{Namespace: opts.Namespace, Name: opts.Name}, workload); err != nil {
-			return err
-		}
-		if err := opts.OutputWorkload(c, workload); err != nil {
-			return err
-		}
+	if okToApply {
+		anyTail := opts.Tail || opts.TailTimestamps
+		if opts.Wait || anyTail {
+			cli.PrintPrompt(shouldPrint, c.Infof, "Waiting for workload %q to become ready...\n", opts.Name)
 
-		return nil
-	}
+			workers := opts.WaitToBeReady(c, workload)
 
-	anyTail := opts.Tail || opts.TailTimestamps
-	if okToApply && (opts.Wait || anyTail) {
-		c.Infof("Waiting for workload %q to become ready...\n", opts.Name)
+			if anyTail {
+				workers = append(workers, func(ctx context.Context) error {
+					selector, err := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workload.Name))
+					if err != nil {
+						return err
+					}
+					containers := []string{}
+					return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Minute, opts.TailTimestamps)
+				})
+			}
 
-		workers = opts.WaitToBeReady(c, workload)
-
-		if anyTail {
-			workers = append(workers, func(ctx context.Context) error {
-				selector, err := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workload.Name))
-				if err != nil {
-					panic(err)
+			err := wait.Race(ctx, opts.WaitTimeout, workers)
+			// print wait error only if output is not set or it was not used with --yes
+			if err != nil {
+				if err == context.DeadlineExceeded {
+					cli.PrintPrompt(shouldPrint, c.Printf, "%s timeout after %s waiting for %q to become ready\n", printer.Serrorf("Error:"), opts.WaitTimeout, workload.Name)
+				} else {
+					cli.PrintPrompt(shouldPrint, c.Eprintf, "%s %s\n", printer.Serrorf("Error:"), err)
 				}
-				containers := []string{}
-				return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Minute, opts.TailTimestamps)
-			})
+			}
+			// do not return if --output is set
+			// because workload has to be printed despite it's in a failing state
+			if err != nil && opts.Output == "" {
+				return cli.SilenceError(err)
+			}
+
+			// since there is a possibility that wait failed but did not return
+			// make sure this prompt is printed only if there is no error
+			if err == nil {
+				cli.PrintPrompt(shouldPrint, c.Infof, "Workload %q is ready\n\n", workload.Name)
+			}
 		}
 
-		if err := opts.WaitError(ctx, c, workload, workers); err != nil {
-			return err
+		if opts.Output != "" {
+			// once the workload is applied, get it as is in the cluster
+			if err := c.Get(ctx, client.ObjectKey{Namespace: opts.Namespace, Name: opts.Name}, workload); err != nil {
+				return err
+			}
+			if err := opts.OutputWorkload(c, workload); err != nil {
+				return err
+			}
 		}
-
-		c.Infof("Workload %q is ready\n\n", workload.Name)
 	}
 
 	return nil

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -256,30 +256,9 @@ To get status: "tanzu apps workload get my-workload"
 `,
 		},
 		{
-			Name: "successful wait to create with ready cond - output yaml ",
+			Name: "create - output yaml",
 			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
 				flags.OutputFlagName, printer.OutputFormatYaml, flags.YesFlagName},
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Status: cartov1alpha1.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:   cartov1alpha1.WorkloadConditionReady,
-								Status: metav1.ConditionTrue,
-							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
-			},
 			GivenObjects: givenNamespaceDefault,
 			ExpectCreates: []client.Object{
 				&cartov1alpha1.Workload{
@@ -320,58 +299,10 @@ status:
 `,
 		},
 		{
-			Name: "wait error on create - output yaml ",
+			Name: "create - output yaml with wait",
 			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
-				flags.OutputFlagName, printer.OutputFormatYaml, flags.YesFlagName},
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Status: cartov1alpha1.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:    cartov1alpha1.WorkloadConditionReady,
-								Status:  metav1.ConditionFalse,
-								Reason:  "OopsieDoodle",
-								Message: "a hopefully informative message about what went wrong",
-							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
-			},
+				flags.OutputFlagName, printer.OutputFormatYaml, flags.WaitFlagName, flags.YesFlagName},
 			GivenObjects: givenNamespaceDefault,
-			ExpectCreates: []client.Object{
-				&cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-						Labels:    map[string]string{},
-					},
-					Spec: cartov1alpha1.WorkloadSpec{
-						Source: &cartov1alpha1.Source{
-							Git: &cartov1alpha1.GitSource{
-								URL: gitRepo,
-								Ref: cartov1alpha1.GitRef{
-									Branch: gitBranch,
-								},
-							},
-						},
-					},
-				},
-			},
-			ShouldError: true,
-		},
-		{
-			Name: "successful wait to create with ready cond - output json ",
-			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
-				flags.OutputFlagName, printer.OutputFormatJson, flags.YesFlagName},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -393,6 +324,48 @@ status:
 				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
 				return ctx, nil
 			},
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels:    map[string]string{},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: gitRepo,
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  creationTimestamp: null
+  name: my-workload
+  namespace: default
+  resourceVersion: "1"
+spec:
+  source:
+    git:
+      ref:
+        branch: main
+      url: https://example.com/repo.git
+status:
+  supplyChainRef: {}
+`,
+		},
+		{
+			Name: "create - output json",
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
+				flags.OutputFlagName, printer.OutputFormatJson, flags.YesFlagName},
 			GivenObjects: givenNamespaceDefault,
 			ExpectCreates: []client.Object{
 				&cartov1alpha1.Workload{
@@ -415,21 +388,21 @@ status:
 			},
 			ExpectOutput: `
 {
-	"kind": "Workload",
 	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
 	"metadata": {
+		"creationTimestamp": null,
 		"name": "my-workload",
 		"namespace": "default",
-		"resourceVersion": "1",
-		"creationTimestamp": null
+		"resourceVersion": "1"
 	},
 	"spec": {
 		"source": {
 			"git": {
-				"url": "https://example.com/repo.git",
 				"ref": {
 					"branch": "main"
-				}
+				},
+				"url": "https://example.com/repo.git"
 			}
 		}
 	},
@@ -440,7 +413,7 @@ status:
 `,
 		},
 		{
-			Name: "wait error on update - output yaml",
+			Name: "update - output yaml",
 			Args: []string{workloadName, flags.ServiceRefFlagName,
 				"database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db",
 				flags.OutputFlagName, printer.OutputFormatYaml, flags.YesFlagName},
@@ -448,30 +421,15 @@ status:
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
 						d.Image("ubuntu:bionic")
-					}),
-			},
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Status: cartov1alpha1.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:    cartov1alpha1.WorkloadConditionReady,
-								Status:  metav1.ConditionFalse,
-								Reason:  "OopsieDoodle",
-								Message: "a hopefully informative message about what went wrong",
-							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
+					}).StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
+					d.Conditions(metav1.Condition{
+						Type:   "my-type",
+						Status: metav1.ConditionTrue,
+					}, metav1.Condition{
+						Type:   "my-other-type",
+						Status: metav1.ConditionTrue,
+					})
+				}),
 			},
 			ExpectUpdates: []client.Object{
 				&cartov1alpha1.Workload{
@@ -492,58 +450,15 @@ status:
 							},
 						},
 					},
-				},
-			},
-			ShouldError: true,
-		},
-		{
-			Name: "successful wait to update with ready condition - output yaml",
-			Args: []string{workloadName, flags.ServiceRefFlagName,
-				"database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db",
-				flags.OutputFlagName, printer.OutputFormatYaml, flags.YesFlagName},
-			GivenObjects: []client.Object{
-				parent.
-					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
-						d.Image("ubuntu:bionic")
-					}),
-			},
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
 					Status: cartov1alpha1.WorkloadStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:   cartov1alpha1.WorkloadConditionReady,
+								Type:   "my-type",
 								Status: metav1.ConditionTrue,
 							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
-			},
-			ExpectUpdates: []client.Object{
-				&cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Spec: cartov1alpha1.WorkloadSpec{
-						Image: "ubuntu:bionic",
-						ServiceClaims: []cartov1alpha1.WorkloadServiceClaim{
 							{
-								Name: "database",
-								Ref: &cartov1alpha1.WorkloadServiceClaimReference{
-									APIVersion: "services.tanzu.vmware.com/v1alpha1",
-									Kind:       "PostgreSQL",
-									Name:       "my-prod-db",
-								},
+								Type:   "my-other-type",
+								Status: metav1.ConditionTrue,
 							},
 						},
 					},
@@ -567,40 +482,38 @@ spec:
       kind: PostgreSQL
       name: my-prod-db
 status:
+  conditions:
+  - lastTransitionTime: null
+    message: ""
+    reason: ""
+    status: "True"
+    type: my-type
+  - lastTransitionTime: null
+    message: ""
+    reason: ""
+    status: "True"
+    type: my-other-type
   supplyChainRef: {}
 `,
 		},
 		{
-			Name: "successful wait to update with ready condition - output json",
+			Name: "update - output json",
 			Args: []string{workloadName, flags.ServiceRefFlagName,
 				"database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db",
-				flags.OutputFlagName, printer.OutputFormatJson, flags.WaitFlagName, flags.YesFlagName},
+				flags.OutputFlagName, printer.OutputFormatJson, flags.YesFlagName},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
 						d.Image("ubuntu:bionic")
-					}),
-			},
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Status: cartov1alpha1.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:   cartov1alpha1.WorkloadConditionReady,
-								Status: metav1.ConditionTrue,
-							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
+					}).StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
+					d.Conditions(metav1.Condition{
+						Type:   "my-type",
+						Status: metav1.ConditionTrue,
+					}, metav1.Condition{
+						Type:   "my-other-type",
+						Status: metav1.ConditionTrue,
+					})
+				}),
 			},
 			ExpectUpdates: []client.Object{
 				&cartov1alpha1.Workload{
@@ -621,17 +534,29 @@ status:
 							},
 						},
 					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   "my-type",
+								Status: metav1.ConditionTrue,
+							},
+							{
+								Type:   "my-other-type",
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
 				},
 			},
 			ExpectOutput: `
 {
-	"kind": "Workload",
 	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
 	"metadata": {
+		"creationTimestamp": "1970-01-01T00:00:01Z",
 		"name": "my-workload",
 		"namespace": "default",
-		"resourceVersion": "1000",
-		"creationTimestamp": "1970-01-01T00:00:01Z"
+		"resourceVersion": "1000"
 	},
 	"spec": {
 		"image": "ubuntu:bionic",
@@ -647,6 +572,147 @@ status:
 		]
 	},
 	"status": {
+		"conditions": [
+			{
+				"lastTransitionTime": null,
+				"message": "",
+				"reason": "",
+				"status": "True",
+				"type": "my-type"
+			},
+			{
+				"lastTransitionTime": null,
+				"message": "",
+				"reason": "",
+				"status": "True",
+				"type": "my-other-type"
+			}
+		],
+		"supplyChainRef": {}
+	}
+}
+`,
+		},
+		{
+			Name: "update - output json with tail",
+			Args: []string{workloadName, flags.ServiceRefFlagName,
+				"database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db",
+				flags.OutputFlagName, printer.OutputFormatJson, flags.TailFlagName, flags.YesFlagName},
+			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
+				workload := &cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   cartov1alpha1.WorkloadConditionReady,
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				}
+				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
+					{Type: watch.Modified, Object: workload},
+				})
+				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
+
+				tailer := &logs.FakeTailer{}
+				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, false).Return(nil).Once()
+				ctx = logs.StashTailer(ctx, tailer)
+
+				return ctx, nil
+			},
+			GivenObjects: []client.Object{
+				parent.
+					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
+						d.Image("ubuntu:bionic")
+					}).StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
+					d.Conditions(metav1.Condition{
+						Type:   "my-type",
+						Status: metav1.ConditionTrue,
+					}, metav1.Condition{
+						Type:   "my-other-type",
+						Status: metav1.ConditionTrue,
+					})
+				}),
+			},
+			ExpectUpdates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Image: "ubuntu:bionic",
+						ServiceClaims: []cartov1alpha1.WorkloadServiceClaim{
+							{
+								Name: "database",
+								Ref: &cartov1alpha1.WorkloadServiceClaimReference{
+									APIVersion: "services.tanzu.vmware.com/v1alpha1",
+									Kind:       "PostgreSQL",
+									Name:       "my-prod-db",
+								},
+							},
+						},
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   "my-type",
+								Status: metav1.ConditionTrue,
+							},
+							{
+								Type:   "my-other-type",
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+...tail output...
+{
+	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
+	"metadata": {
+		"creationTimestamp": "1970-01-01T00:00:01Z",
+		"name": "my-workload",
+		"namespace": "default",
+		"resourceVersion": "1000"
+	},
+	"spec": {
+		"image": "ubuntu:bionic",
+		"serviceClaims": [
+			{
+				"name": "database",
+				"ref": {
+					"apiVersion": "services.tanzu.vmware.com/v1alpha1",
+					"kind": "PostgreSQL",
+					"name": "my-prod-db"
+				}
+			}
+		]
+	},
+	"status": {
+		"conditions": [
+			{
+				"lastTransitionTime": null,
+				"message": "",
+				"reason": "",
+				"status": "True",
+				"type": "my-type"
+			},
+			{
+				"lastTransitionTime": null,
+				"message": "",
+				"reason": "",
+				"status": "True",
+				"type": "my-other-type"
+			}
+		],
 		"supplyChainRef": {}
 	}
 }
@@ -4265,7 +4331,15 @@ To get status: "tanzu apps workload get my-workload"
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
 						d.Image("ubuntu:bionic")
-					}),
+					}).StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
+					d.Conditions(metav1.Condition{
+						Type:   "my-type",
+						Status: metav1.ConditionTrue,
+					}, metav1.Condition{
+						Type:   "my-other-type",
+						Status: metav1.ConditionTrue,
+					})
+				}),
 			},
 			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
 				c.ExpectString(clitesting.ToInteractTerminal("? Really update the workload %q? [yN]: ", workloadName))
@@ -4274,27 +4348,6 @@ To get status: "tanzu apps workload get my-workload"
 
 To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
 To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
-			},
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Status: cartov1alpha1.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:   cartov1alpha1.WorkloadConditionReady,
-								Status: metav1.ConditionTrue,
-							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
 			},
 			ExpectUpdates: []client.Object{
 				&cartov1alpha1.Workload{
@@ -4312,6 +4365,18 @@ To get status: "tanzu apps workload get %s"`, workloadName, workloadName, worklo
 									Kind:       "PostgreSQL",
 									Name:       "my-prod-db",
 								},
+							},
+						},
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   "my-type",
+								Status: metav1.ConditionTrue,
+							},
+							{
+								Type:   "my-other-type",
+								Status: metav1.ConditionTrue,
 							},
 						},
 					},
@@ -4338,13 +4403,13 @@ To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
 To get status: "tanzu apps workload get my-workload"
 
 {
-	"kind": "Workload",
 	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
 	"metadata": {
+		"creationTimestamp": "1970-01-01T00:00:01Z",
 		"name": "my-workload",
 		"namespace": "default",
-		"resourceVersion": "1000",
-		"creationTimestamp": "1970-01-01T00:00:01Z"
+		"resourceVersion": "1000"
 	},
 	"spec": {
 		"image": "ubuntu:bionic",
@@ -4360,96 +4425,25 @@ To get status: "tanzu apps workload get my-workload"
 		]
 	},
 	"status": {
+		"conditions": [
+			{
+				"lastTransitionTime": null,
+				"message": "",
+				"reason": "",
+				"status": "True",
+				"type": "my-type"
+			},
+			{
+				"lastTransitionTime": null,
+				"message": "",
+				"reason": "",
+				"status": "True",
+				"type": "my-other-type"
+			}
+		],
 		"supplyChainRef": {}
 	}
 }
-`, clitesting.ToInteractTerminal("❓ Really update the workload %q? [yN]: y", workloadName), workloadName),
-		},
-		{
-			Name: "wait error - output workload after update in json format",
-			Args: []string{workloadName, flags.ServiceRefFlagName,
-				"database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db",
-				flags.OutputFlagName, printer.OutputFormatJson},
-			GivenObjects: []client.Object{
-				parent.
-					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
-						d.Image("ubuntu:bionic")
-					}),
-			},
-			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
-				c.ExpectString(clitesting.ToInteractTerminal("? Really update the workload %q? [yN]: ", workloadName))
-				c.Send(clitesting.InteractInputLine("y"))
-				c.ExpectString(clitesting.ToInteractOutput(`👍 Updated workload %q
-
-To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
-To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
-			},
-			ShouldError: true,
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Status: cartov1alpha1.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:    cartov1alpha1.WorkloadConditionReady,
-								Status:  metav1.ConditionFalse,
-								Reason:  "OopsieDoodle",
-								Message: "a hopefully informative message about what went wrong",
-							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
-			},
-			ExpectUpdates: []client.Object{
-				&cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Spec: cartov1alpha1.WorkloadSpec{
-						Image: "ubuntu:bionic",
-						ServiceClaims: []cartov1alpha1.WorkloadServiceClaim{
-							{
-								Name: "database",
-								Ref: &cartov1alpha1.WorkloadServiceClaimReference{
-									APIVersion: "services.tanzu.vmware.com/v1alpha1",
-									Kind:       "PostgreSQL",
-									Name:       "my-prod-db",
-								},
-							},
-						},
-					},
-				},
-			},
-			ExpectOutput: fmt.Sprintf(`
-🔎 Update workload:
-...
-  5,  5   |  name: my-workload
-  6,  6   |  namespace: default
-  7,  7   |spec:
-  8,  8   |  image: ubuntu:bionic
-      9 + |  serviceClaims:
-     10 + |  - name: database
-     11 + |    ref:
-     12 + |      apiVersion: services.tanzu.vmware.com/v1alpha1
-     13 + |      kind: PostgreSQL
-     14 + |      name: my-prod-db
-%s
-
-👍 Updated workload %q
-
-To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
-To get status: "tanzu apps workload get my-workload"
-
-Error: Failed to become ready: a hopefully informative message about what went wrong
 `, clitesting.ToInteractTerminal("❓ Really update the workload %q? [yN]: y", workloadName), workloadName),
 		},
 		{
@@ -4461,7 +4455,15 @@ Error: Failed to become ready: a hopefully informative message about what went w
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
 						d.Image("ubuntu:bionic")
-					}),
+					}).StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
+					d.Conditions(metav1.Condition{
+						Type:   "my-type",
+						Status: metav1.ConditionTrue,
+					}, metav1.Condition{
+						Type:   "my-other-type",
+						Status: metav1.ConditionTrue,
+					})
+				}),
 			},
 			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
 				c.ExpectString(clitesting.ToInteractTerminal("? Really update the workload %q? [yN]: ", workloadName))
@@ -4470,27 +4472,6 @@ Error: Failed to become ready: a hopefully informative message about what went w
 
 To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
 To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
-			},
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Status: cartov1alpha1.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:   cartov1alpha1.WorkloadConditionReady,
-								Status: metav1.ConditionTrue,
-							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
 			},
 			ExpectUpdates: []client.Object{
 				&cartov1alpha1.Workload{
@@ -4508,6 +4489,18 @@ To get status: "tanzu apps workload get %s"`, workloadName, workloadName, worklo
 									Kind:       "PostgreSQL",
 									Name:       "my-prod-db",
 								},
+							},
+						},
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   "my-type",
+								Status: metav1.ConditionTrue,
+							},
+							{
+								Type:   "my-other-type",
+								Status: metav1.ConditionTrue,
 							},
 						},
 					},
@@ -4550,22 +4543,25 @@ spec:
       kind: PostgreSQL
       name: my-prod-db
 status:
+  conditions:
+  - lastTransitionTime: null
+    message: ""
+    reason: ""
+    status: "True"
+    type: my-type
+  - lastTransitionTime: null
+    message: ""
+    reason: ""
+    status: "True"
+    type: my-other-type
   supplyChainRef: {}
 `, clitesting.ToInteractTerminal("❓ Really update the workload %q? [yN]: y", workloadName), workloadName),
 		},
 		{
-			Name:         "output workload after create in yaml format",
-			GivenObjects: givenNamespaceDefault,
-			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
-				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatYaml},
-			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
-				c.ExpectString(clitesting.ToInteractTerminal("Do you want to create this workload? [yN]: "))
-				c.Send(clitesting.InteractInputLine("y"))
-				c.ExpectString(clitesting.ToInteractOutput(`👍 Created workload %q
-
-To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
-To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
-			},
+			Name: "output workload after update in yaml format with wait error",
+			Args: []string{workloadName, flags.ServiceRefFlagName,
+				"database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db",
+				flags.OutputFlagName, printer.OutputFormatYml, flags.WaitFlagName},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -4581,11 +4577,132 @@ To get status: "tanzu apps workload get %s"`, workloadName, workloadName, worklo
 						},
 					},
 				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
+				fakeWatcher := watchfakes.NewFakeWithWatch(true, config.Client, []watch.Event{
 					{Type: watch.Modified, Object: workload},
 				})
 				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
 				return ctx, nil
+			},
+			GivenObjects: []client.Object{
+				parent.
+					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
+						d.Image("ubuntu:bionic")
+					}).StatusDie(func(d *diecartov1alpha1.WorkloadStatusDie) {
+					d.Conditions(metav1.Condition{
+						Type:   "my-type",
+						Status: metav1.ConditionTrue,
+					}, metav1.Condition{
+						Type:   "my-other-type",
+						Status: metav1.ConditionTrue,
+					})
+				}),
+			},
+			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
+				c.ExpectString(clitesting.ToInteractTerminal("? Really update the workload %q? [yN]: ", workloadName))
+				c.Send(clitesting.InteractInputLine("y"))
+				c.ExpectString(clitesting.ToInteractOutput(`👍 Updated workload %q
+
+To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
+To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
+			},
+			ExpectUpdates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Image: "ubuntu:bionic",
+						ServiceClaims: []cartov1alpha1.WorkloadServiceClaim{
+							{
+								Name: "database",
+								Ref: &cartov1alpha1.WorkloadServiceClaimReference{
+									APIVersion: "services.tanzu.vmware.com/v1alpha1",
+									Kind:       "PostgreSQL",
+									Name:       "my-prod-db",
+								},
+							},
+						},
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   "my-type",
+								Status: metav1.ConditionTrue,
+							},
+							{
+								Type:   "my-other-type",
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+🔎 Update workload:
+...
+  5,  5   |  name: my-workload
+  6,  6   |  namespace: default
+  7,  7   |spec:
+  8,  8   |  image: ubuntu:bionic
+      9 + |  serviceClaims:
+     10 + |  - name: database
+     11 + |    ref:
+     12 + |      apiVersion: services.tanzu.vmware.com/v1alpha1
+     13 + |      kind: PostgreSQL
+     14 + |      name: my-prod-db
+%s
+
+👍 Updated workload %q
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+Waiting for workload "my-workload" to become ready...
+Error: failed to create watcher
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  creationTimestamp: "1970-01-01T00:00:01Z"
+  name: my-workload
+  namespace: default
+  resourceVersion: "1000"
+spec:
+  image: ubuntu:bionic
+  serviceClaims:
+  - name: database
+    ref:
+      apiVersion: services.tanzu.vmware.com/v1alpha1
+      kind: PostgreSQL
+      name: my-prod-db
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: ""
+    reason: ""
+    status: "True"
+    type: my-type
+  - lastTransitionTime: null
+    message: ""
+    reason: ""
+    status: "True"
+    type: my-other-type
+  supplyChainRef: {}
+`, clitesting.ToInteractTerminal("❓ Really update the workload %q? [yN]: y", workloadName), workloadName),
+		},
+		{
+			Name:         "output workload after create in yaml format",
+			GivenObjects: givenNamespaceDefault,
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
+				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatYaml},
+			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
+				c.ExpectString(clitesting.ToInteractTerminal("Do you want to create this workload? [yN]: "))
+				c.Send(clitesting.InteractInputLine("y"))
+				c.ExpectString(clitesting.ToInteractOutput(`👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
+To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
 			},
 			ExpectCreates: []client.Object{
 				&cartov1alpha1.Workload{
@@ -4652,7 +4769,7 @@ status:
 `, clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: y"), workloadName),
 		},
 		{
-			Name:         "output workload after create in yaml format",
+			Name:         "output workload after create in json format",
 			GivenObjects: givenNamespaceDefault,
 			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
 				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatJson},
@@ -4663,27 +4780,6 @@ status:
 
 To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
 To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
-			},
-			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
-				workload := &cartov1alpha1.Workload{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: defaultNamespace,
-						Name:      workloadName,
-					},
-					Status: cartov1alpha1.WorkloadStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:   cartov1alpha1.WorkloadConditionReady,
-								Status: metav1.ConditionTrue,
-							},
-						},
-					},
-				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
-					{Type: watch.Modified, Object: workload},
-				})
-				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
-				return ctx, nil
 			},
 			ExpectCreates: []client.Object{
 				&cartov1alpha1.Workload{
@@ -4730,24 +4826,24 @@ To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
 To get status: "tanzu apps workload get my-workload"
 
 {
-	"kind": "Workload",
 	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
 	"metadata": {
-		"name": "my-workload",
-		"namespace": "default",
-		"resourceVersion": "1",
 		"creationTimestamp": null,
 		"labels": {
 			"apps.tanzu.vmware.com/workload-type": "web"
-		}
+		},
+		"name": "my-workload",
+		"namespace": "default",
+		"resourceVersion": "1"
 	},
 	"spec": {
 		"source": {
 			"git": {
-				"url": "https://example.com/repo.git",
 				"ref": {
 					"branch": "main"
-				}
+				},
+				"url": "https://example.com/repo.git"
 			}
 		}
 	},
@@ -4758,10 +4854,10 @@ To get status: "tanzu apps workload get my-workload"
 `, clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: y"), workloadName),
 		},
 		{
-			Name:         "wait error - output workload after create in yaml format",
+			Name:         "output workload after create in json format with tail error",
 			GivenObjects: givenNamespaceDefault,
 			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
-				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatJson},
+				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatJson, flags.TailFlagName},
 			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
 				c.ExpectString(clitesting.ToInteractTerminal("Do you want to create this workload? [yN]: "))
 				c.Send(clitesting.InteractInputLine("y"))
@@ -4779,21 +4875,24 @@ To get status: "tanzu apps workload get %s"`, workloadName, workloadName, worklo
 					Status: cartov1alpha1.WorkloadStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:    cartov1alpha1.WorkloadConditionReady,
-								Status:  metav1.ConditionFalse,
-								Reason:  "OopsieDoodle",
-								Message: "a hopefully informative message about what went wrong",
+								Type:   cartov1alpha1.WorkloadConditionReady,
+								Status: metav1.ConditionTrue,
 							},
 						},
 					},
 				}
-				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
+				fakeWatcher := watchfakes.NewFakeWithWatch(true, config.Client, []watch.Event{
 					{Type: watch.Modified, Object: workload},
 				})
 				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
+
+				tailer := &logs.FakeTailer{}
+				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, false).Return(nil).Once()
+				ctx = logs.StashTailer(ctx, tailer)
+
 				return ctx, nil
 			},
-			ShouldError: true,
 			ExpectCreates: []client.Object{
 				&cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -4838,7 +4937,35 @@ To get status: "tanzu apps workload get %s"`, workloadName, workloadName, worklo
 To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
 To get status: "tanzu apps workload get my-workload"
 
-Error: Failed to become ready: a hopefully informative message about what went wrong
+Waiting for workload "my-workload" to become ready...
+...tail output...
+Error: failed to create watcher
+{
+	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
+	"metadata": {
+		"creationTimestamp": null,
+		"labels": {
+			"apps.tanzu.vmware.com/workload-type": "web"
+		},
+		"name": "my-workload",
+		"namespace": "default",
+		"resourceVersion": "1"
+	},
+	"spec": {
+		"source": {
+			"git": {
+				"ref": {
+					"branch": "main"
+				},
+				"url": "https://example.com/repo.git"
+			}
+		}
+	},
+	"status": {
+		"supplyChainRef": {}
+	}
+}
 `, clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: y"), workloadName),
 		},
 		{

--- a/pkg/commands/workload_create.go
+++ b/pkg/commands/workload_create.go
@@ -126,51 +126,61 @@ func (opts *WorkloadCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		}
 	} else if opts.Output != "" && opts.Yes {
 		// since there are no prompts, set okToCreate to true (accepted through --yes)
-		okToCreate = true
+		okToCreate = opts.Yes
 		if err := c.Create(ctx, workload); err != nil {
 			return err
 		}
 	}
 
-	var workers []wait.Worker
-	if opts.Output != "" && okToCreate {
-		workers = opts.WaitToBeReady(c, workload)
-		if err := opts.WaitError(ctx, c, workload, workers); err != nil {
-			return err
-		}
-		// once the workload is ready, get it as is in the cluster
-		if err := c.Get(ctx, client.ObjectKey{Namespace: opts.Namespace, Name: opts.Name}, workload); err != nil {
-			return err
-		}
-		if err := opts.OutputWorkload(c, workload); err != nil {
-			return err
-		}
+	if okToCreate {
+		anyTail := opts.Tail || opts.TailTimestamps
+		if opts.Wait || anyTail {
+			cli.PrintPrompt(shouldPrint, c.Infof, "Waiting for workload %q to become ready...\n", opts.Name)
 
-		return nil
-	}
+			workers := opts.WaitToBeReady(c, workload)
 
-	anyTail := opts.Tail || opts.TailTimestamps
-	if okToCreate && (opts.Wait || anyTail) {
-		c.Infof("Waiting for workload %q to become ready...\n", opts.Name)
+			if anyTail {
+				workers = append(workers, func(ctx context.Context) error {
+					selector, err := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workload.Name))
+					if err != nil {
+						return err
+					}
+					containers := []string{}
+					return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Minute, opts.TailTimestamps)
+				})
+			}
 
-		workers = opts.WaitToBeReady(c, workload)
-
-		if anyTail {
-			workers = append(workers, func(ctx context.Context) error {
-				selector, err := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workload.Name))
-				if err != nil {
-					panic(err)
+			err := wait.Race(ctx, opts.WaitTimeout, workers)
+			// print wait error only if output is not set or it was not used with --yes
+			if err != nil {
+				if err == context.DeadlineExceeded {
+					cli.PrintPrompt(shouldPrint, c.Printf, "%s timeout after %s waiting for %q to become ready\n", printer.Serrorf("Error:"), opts.WaitTimeout, workload.Name)
+				} else {
+					cli.PrintPrompt(shouldPrint, c.Eprintf, "%s %s\n", printer.Serrorf("Error:"), err)
 				}
-				containers := []string{}
-				return logs.Tail(ctx, c, opts.Namespace, selector, containers, time.Minute, opts.TailTimestamps)
-			})
+			}
+			// do not return if --output is set
+			// because workload has to be printed despite it's in a failing state
+			if err != nil && opts.Output == "" {
+				return cli.SilenceError(err)
+			}
+
+			// since there is a possibility that wait failed but did not return
+			// make sure this prompt is printed only if there is no error
+			if err == nil {
+				cli.PrintPrompt(shouldPrint, c.Infof, "Workload %q is ready\n\n", workload.Name)
+			}
 		}
 
-		if err := opts.WaitError(ctx, c, workload, workers); err != nil {
-			return err
+		if opts.Output != "" {
+			// once the workload is created, get it as is in the cluster
+			if err := c.Get(ctx, client.ObjectKey{Namespace: opts.Namespace, Name: opts.Name}, workload); err != nil {
+				return err
+			}
+			if err := opts.OutputWorkload(c, workload); err != nil {
+				return err
+			}
 		}
-
-		c.Infof("Workload %q is ready\n\n", workload.Name)
 	}
 
 	return nil

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/commands"
 	diecartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/dies/cartographer/v1alpha1"
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/flags"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/printer"
 )
 
 func TestWorkloadCreateOptionsValidate(t *testing.T) {
@@ -143,6 +144,120 @@ spec:
       url: https://example.com/repo.git
 status:
   supplyChainRef: {}
+`,
+		},
+		{
+			Name: "create - output yaml with wait",
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
+				flags.OutputFlagName, printer.OutputFormatYaml, flags.WaitFlagName, flags.YesFlagName},
+			GivenObjects: givenNamespaceDefault,
+			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
+				workload := &cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   cartov1alpha1.WorkloadConditionReady,
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				}
+				fakeWatcher := watchfakes.NewFakeWithWatch(false, config.Client, []watch.Event{
+					{Type: watch.Modified, Object: workload},
+				})
+				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
+				return ctx, nil
+			},
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels:    map[string]string{},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: gitRepo,
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  creationTimestamp: null
+  name: my-workload
+  namespace: default
+  resourceVersion: "1"
+spec:
+  source:
+    git:
+      ref:
+        branch: main
+      url: https://example.com/repo.git
+status:
+  supplyChainRef: {}
+`,
+		},
+		{
+			Name: "create - output json",
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
+				flags.OutputFlagName, printer.OutputFormatJson, flags.YesFlagName},
+			GivenObjects: givenNamespaceDefault,
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels:    map[string]string{},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: gitRepo,
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+{
+	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
+	"metadata": {
+		"creationTimestamp": null,
+		"name": "my-workload",
+		"namespace": "default",
+		"resourceVersion": "1"
+	},
+	"spec": {
+		"source": {
+			"git": {
+				"ref": {
+					"branch": "main"
+				},
+				"url": "https://example.com/repo.git"
+			}
+		}
+	},
+	"status": {
+		"supplyChainRef": {}
+	}
+}
 `,
 		},
 		{
@@ -1394,6 +1509,398 @@ invalid input (not y, n, yes, or no)
 Skipping workload %q`,
 				clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: m"),
 				clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: n"), workloadName),
+		},
+
+		{
+			Name:         "output workload after create in yaml format",
+			GivenObjects: givenNamespaceDefault,
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
+				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatYaml},
+			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
+				c.ExpectString(clitesting.ToInteractTerminal("Do you want to create this workload? [yN]: "))
+				c.Send(clitesting.InteractInputLine("y"))
+				c.ExpectString(clitesting.ToInteractOutput(`👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
+To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
+			},
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							"apps.tanzu.vmware.com/workload-type": "web",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: gitRepo,
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+🔎 Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  labels:
+      6 + |    apps.tanzu.vmware.com/workload-type: web
+      7 + |  name: my-workload
+      8 + |  namespace: default
+      9 + |spec:
+     10 + |  source:
+     11 + |    git:
+     12 + |      ref:
+     13 + |        branch: main
+     14 + |      url: https://example.com/repo.git
+%s
+
+👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+---
+apiVersion: carto.run/v1alpha1
+kind: Workload
+metadata:
+  creationTimestamp: null
+  labels:
+    apps.tanzu.vmware.com/workload-type: web
+  name: my-workload
+  namespace: default
+  resourceVersion: "1"
+spec:
+  source:
+    git:
+      ref:
+        branch: main
+      url: https://example.com/repo.git
+status:
+  supplyChainRef: {}
+`, clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: y"), workloadName),
+		},
+		{
+			Name:         "output workload after create in json format",
+			GivenObjects: givenNamespaceDefault,
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
+				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatJson},
+			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
+				c.ExpectString(clitesting.ToInteractTerminal("Do you want to create this workload? [yN]: "))
+				c.Send(clitesting.InteractInputLine("y"))
+				c.ExpectString(clitesting.ToInteractOutput(`👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
+To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
+			},
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							"apps.tanzu.vmware.com/workload-type": "web",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: gitRepo,
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+🔎 Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  labels:
+      6 + |    apps.tanzu.vmware.com/workload-type: web
+      7 + |  name: my-workload
+      8 + |  namespace: default
+      9 + |spec:
+     10 + |  source:
+     11 + |    git:
+     12 + |      ref:
+     13 + |        branch: main
+     14 + |      url: https://example.com/repo.git
+%s
+
+👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+{
+	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
+	"metadata": {
+		"creationTimestamp": null,
+		"labels": {
+			"apps.tanzu.vmware.com/workload-type": "web"
+		},
+		"name": "my-workload",
+		"namespace": "default",
+		"resourceVersion": "1"
+	},
+	"spec": {
+		"source": {
+			"git": {
+				"ref": {
+					"branch": "main"
+				},
+				"url": "https://example.com/repo.git"
+			}
+		}
+	},
+	"status": {
+		"supplyChainRef": {}
+	}
+}
+`, clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: y"), workloadName),
+		},
+		{
+			Name:         "output workload after create in json format with tail error",
+			GivenObjects: givenNamespaceDefault,
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
+				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatJson, flags.TailFlagName},
+			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
+				c.ExpectString(clitesting.ToInteractTerminal("Do you want to create this workload? [yN]: "))
+				c.Send(clitesting.InteractInputLine("y"))
+				c.ExpectString(clitesting.ToInteractOutput(`👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
+To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
+			},
+			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
+				workload := &cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   cartov1alpha1.WorkloadConditionReady,
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				}
+				fakeWatcher := watchfakes.NewFakeWithWatch(true, config.Client, []watch.Event{
+					{Type: watch.Modified, Object: workload},
+				})
+				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
+
+				tailer := &logs.FakeTailer{}
+				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, false).Return(nil).Once()
+				ctx = logs.StashTailer(ctx, tailer)
+
+				return ctx, nil
+			},
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							"apps.tanzu.vmware.com/workload-type": "web",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: gitRepo,
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+🔎 Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  labels:
+      6 + |    apps.tanzu.vmware.com/workload-type: web
+      7 + |  name: my-workload
+      8 + |  namespace: default
+      9 + |spec:
+     10 + |  source:
+     11 + |    git:
+     12 + |      ref:
+     13 + |        branch: main
+     14 + |      url: https://example.com/repo.git
+%s
+
+👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+Waiting for workload "my-workload" to become ready...
+...tail output...
+Error: failed to create watcher
+{
+	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
+	"metadata": {
+		"creationTimestamp": null,
+		"labels": {
+			"apps.tanzu.vmware.com/workload-type": "web"
+		},
+		"name": "my-workload",
+		"namespace": "default",
+		"resourceVersion": "1"
+	},
+	"spec": {
+		"source": {
+			"git": {
+				"ref": {
+					"branch": "main"
+				},
+				"url": "https://example.com/repo.git"
+			}
+		}
+	},
+	"status": {
+		"supplyChainRef": {}
+	}
+}
+`, clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: y"), workloadName),
+		},
+		{
+			Name:         "output workload after create in json format with wait error",
+			GivenObjects: givenNamespaceDefault,
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
+				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatJson, flags.WaitFlagName},
+			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
+				c.ExpectString(clitesting.ToInteractTerminal("Do you want to create this workload? [yN]: "))
+				c.Send(clitesting.InteractInputLine("y"))
+				c.ExpectString(clitesting.ToInteractOutput(`👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail %s --timestamp --since 1h"
+To get status: "tanzu apps workload get %s"`, workloadName, workloadName, workloadName))
+			},
+			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
+				workload := &cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+					},
+					Status: cartov1alpha1.WorkloadStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   cartov1alpha1.WorkloadConditionReady,
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				}
+				fakeWatcher := watchfakes.NewFakeWithWatch(true, config.Client, []watch.Event{
+					{Type: watch.Modified, Object: workload},
+				})
+				ctx = watchhelper.WithWatcher(ctx, fakeWatcher)
+
+				tailer := &logs.FakeTailer{}
+				selector, _ := labels.Parse(fmt.Sprintf("%s=%s", cartov1alpha1.WorkloadLabelName, workloadName))
+				tailer.On("Tail", mock.Anything, "default", selector, []string{}, time.Minute, false).Return(nil).Once()
+				ctx = logs.StashTailer(ctx, tailer)
+
+				return ctx, nil
+			},
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							"apps.tanzu.vmware.com/workload-type": "web",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &cartov1alpha1.Source{
+							Git: &cartov1alpha1.GitSource{
+								URL: gitRepo,
+								Ref: cartov1alpha1.GitRef{
+									Branch: gitBranch,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+🔎 Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  labels:
+      6 + |    apps.tanzu.vmware.com/workload-type: web
+      7 + |  name: my-workload
+      8 + |  namespace: default
+      9 + |spec:
+     10 + |  source:
+     11 + |    git:
+     12 + |      ref:
+     13 + |        branch: main
+     14 + |      url: https://example.com/repo.git
+%s
+
+👍 Created workload %q
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+Waiting for workload "my-workload" to become ready...
+Error: failed to create watcher
+{
+	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
+	"metadata": {
+		"creationTimestamp": null,
+		"labels": {
+			"apps.tanzu.vmware.com/workload-type": "web"
+		},
+		"name": "my-workload",
+		"namespace": "default",
+		"resourceVersion": "1"
+	},
+	"spec": {
+		"source": {
+			"git": {
+				"ref": {
+					"branch": "main"
+				},
+				"url": "https://example.com/repo.git"
+			}
+		}
+	},
+	"status": {
+		"supplyChainRef": {}
+	}
+}
+`, clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: y"), workloadName),
 		},
 	}
 

--- a/pkg/commands/workload_get_test.go
+++ b/pkg/commands/workload_get_test.go
@@ -1581,26 +1581,26 @@ status:
 			},
 			ExpectOutput: `
 {
-	"kind": "Workload",
 	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
 	"metadata": {
-		"name": "my-workload",
-		"namespace": "default",
-		"resourceVersion": "999",
 		"creationTimestamp": "1970-01-01T00:00:01Z",
 		"labels": {
 			"app.kubernetes.io/part-of": "my-workload"
-		}
+		},
+		"name": "my-workload",
+		"namespace": "default",
+		"resourceVersion": "999"
 	},
 	"spec": {},
 	"status": {
 		"conditions": [
 			{
-				"type": "Ready",
-				"status": "Unknown",
 				"lastTransitionTime": null,
+				"message": "a hopefully informative message about what went wrong",
 				"reason": "Workload Reason",
-				"message": "a hopefully informative message about what went wrong"
+				"status": "Unknown",
+				"type": "Ready"
 			}
 		],
 		"supplyChainRef": {}

--- a/pkg/commands/workload_test.go
+++ b/pkg/commands/workload_test.go
@@ -730,8 +730,6 @@ metadata:
   generation: 1
   labels:
     name: value
-  managedFields:
-  - manager: tanzu
   name: my-workload
   namespace: default
   ownerReferences:
@@ -800,24 +798,24 @@ status:
 		},
 		expected: `
 {
-	"kind": "Workload",
 	"apiVersion": "carto.run/v1alpha1",
+	"kind": "Workload",
 	"metadata": {
-		"name": "my-workload",
-		"namespace": "default",
-		"selfLink": "/default/my-workload",
-		"uid": "uid-xyz",
-		"resourceVersion": "999",
-		"generation": 1,
-		"creationTimestamp": "2021-09-10T15:00:00Z",
-		"deletionTimestamp": "2021-09-10T15:00:00Z",
-		"deletionGracePeriodSeconds": 5,
-		"labels": {
-			"name": "value"
-		},
 		"annotations": {
 			"name": "value"
 		},
+		"creationTimestamp": "2021-09-10T15:00:00Z",
+		"deletionGracePeriodSeconds": 5,
+		"deletionTimestamp": "2021-09-10T15:00:00Z",
+		"finalizers": [
+			"my.finalizer"
+		],
+		"generation": 1,
+		"labels": {
+			"name": "value"
+		},
+		"name": "my-workload",
+		"namespace": "default",
 		"ownerReferences": [
 			{
 				"apiVersion": "v1",
@@ -826,24 +824,19 @@ status:
 				"uid": ""
 			}
 		],
-		"finalizers": [
-			"my.finalizer"
-		],
-		"managedFields": [
-			{
-				"manager": "tanzu"
-			}
-		]
+		"resourceVersion": "999",
+		"selfLink": "/default/my-workload",
+		"uid": "uid-xyz"
 	},
 	"spec": {},
 	"status": {
 		"conditions": [
 			{
-				"type": "Ready",
-				"status": "True",
 				"lastTransitionTime": "2019-06-29T01:44:05Z",
+				"message": "a hopefully informative message about what went wrong",
 				"reason": "No printing status",
-				"message": "a hopefully informative message about what went wrong"
+				"status": "True",
+				"type": "Ready"
 			}
 		],
 		"supplyChainRef": {}


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Remove the waiting step when using `--output` flag since this behavior does not resemble `kubectl`.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #487 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Added unit test
- Created different workloads using `--output` flag with and without `--yes` and checked that output is the same as `kubectl get workload my-workload -oyaml`

### Additional information or special notes for your reviewer

- Added capability to `wait`, `tail` along with `--output`. `wait` will only print the info messages when user does not pass `--yes` to be consistent with the rest of the functionality.
- `tail`, per obvious reasons, will display all the steps info.
- Both of them, after their wait time is over or the workload is in a `ready` status, will return the workload as is in the cluster.
- If user does not pass `wait` or `tail`, then the command will return immediately.
<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
