### PR TITLE
Update go version to 1.20.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
     - name: Grype scan
       run: |
         echo "##[group]Install grype"
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
     - name: Install tanzu cli
       run: |
         $TANZU_VERSION = type .\TANZU_VERSION
@@ -143,7 +143,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
     - name: Install tanzu cli
       run: |
         TANZU_VERSION=$(cat TANZU_VERSION)
@@ -206,7 +206,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.20.x
     - name: Download plugin bundle
       uses: actions/download-artifact@v3
       with:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,7 +22,7 @@ Before submitting a PR, see also [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 You must install these tools:
 
-- [`go`](https://golang.org/doc/install): for compiling the plugin as well as other dependencies - 1.19+
+- [`go`](https://golang.org/doc/install): for compiling the plugin as well as other dependencies - 1.20+
 - [`tanzu CLI`](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/cli/getting-started.md#install-the-latest-release-of-tanzu-cli): for adding the plugin
 - [`git`](https://help.github.com/articles/set-up-git/): for source control
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ lint: ## Run lint tools to identfy stylistic errors
 
 .PHONY: integration-test
 integration-test:  ## Run integration test
-	go test -v -timeout 10m -covermode=atomic -coverprofile=coverage.txt github.com/vmware-tanzu/apps-cli-plugin/testing/e2e/... --tags=integration
+	go test -v -timeout 10m github.com/vmware-tanzu/apps-cli-plugin/testing/e2e/... --tags=integration
 
 .PHONY: prepare
 prepare: generate fmt vet

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/apps-cli-plugin
 
-go 1.19
+go 1.20
 
 require (
 	dies.dev v0.7.0

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/apps-cli-plugin/tools
 
-go 1.19
+go 1.20
 
 require (
 	dies.dev/diegen v0.7.0


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Update go version to 1.20.x in apps-cli. Also updating the CI to run tests on go version 1.20.x.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Validated unit tests as well as integration tests successfully. Installed the app in my local and validated against a local cluster. 

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
The coverage details on integration tests were causing failures with error   ` error generating coverage report: write /dev/pts/3: file already closed`.It is probably due to changes in [os/exec](https://tip.golang.org/doc/go1.20#os/exec) package. This pull request removes the covermod from integration tests as it was neither generating a coverage report, nor we are using the report in the CI. Proposing to enhance the coverage report introducing coverage for integration as well as unit tests using the latest features in GO 1.20