### PR TITLE
Add autocompletion for type flag

### DIFF
--- a/pkg/cli-runtime/client.go
+++ b/pkg/cli-runtime/client.go
@@ -218,13 +218,13 @@ func (c *client) lazyLoadKubernetesClientsetOrDie() *kubernetes.Clientset {
 func (c *client) lazyLoadClientOrDie() crclient.Client {
 	if c.client == nil {
 		restConfig := c.lazyLoadRestConfigOrDie()
-		lazyloadMapper, err := apiutil.NewDynamicRESTMapper(c.KubeRestConfig(), apiutil.WithExperimentalLazyMapper)
+		lazyLoadMapper, err := apiutil.NewDynamicRESTMapper(c.KubeRestConfig(), apiutil.WithExperimentalLazyMapper)
 		if err != nil {
 			fmt.Printf("%s Unable to create rest mapper. signk8s.io/dynamicrestmapper states %s \n", printer.Serrorf("Error:"), err)
 			c.logError(err)
 			os.Exit(2)
 		}
-		client, err := crclient.New(restConfig, crclient.Options{Scheme: c.scheme, Mapper: lazyloadMapper})
+		client, err := crclient.New(restConfig, crclient.Options{Scheme: c.scheme, Mapper: lazyLoadMapper})
 		if err != nil {
 			fmt.Printf("%s Unable to connect: connection refused. Confirm kubeconfig details and try again.\n", printer.Serrorf("Error:"))
 			c.logError(err)

--- a/pkg/cli-runtime/flags.go
+++ b/pkg/cli-runtime/flags.go
@@ -73,16 +73,16 @@ func NamespaceFlag(ctx context.Context, cmd *cobra.Command, c *Config, namespace
 
 	cmd.Flags().StringVarP(namespace, StripDash(NamespaceFlagName), "n", "", "kubernetes `name`space (defaulted from kube config)")
 	cmd.RegisterFlagCompletionFunc(StripDash(NamespaceFlagName), func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		sugestions := []string{}
+		suggestions := []string{}
 		namespaces := &corev1.NamespaceList{}
 		err := c.List(ctx, namespaces)
 		if err != nil {
-			return sugestions, cobra.ShellCompDirectiveNoFileComp
+			return suggestions, cobra.ShellCompDirectiveNoFileComp
 		}
 		for _, n := range namespaces.Items {
-			sugestions = append(sugestions, n.Name)
+			suggestions = append(suggestions, n.Name)
 		}
-		return sugestions, cobra.ShellCompDirectiveNoFileComp
+		return suggestions, cobra.ShellCompDirectiveNoFileComp
 	})
 }
 

--- a/pkg/commands/clustersupplychain_list.go
+++ b/pkg/commands/clustersupplychain_list.go
@@ -52,8 +52,7 @@ func (opts *ClusterSupplyChainListOptions) Validate(ctx context.Context) validat
 
 func (opts *ClusterSupplyChainListOptions) Exec(ctx context.Context, c *cli.Config) error {
 	supplyChain := &cartov1alpha1.ClusterSupplyChainList{}
-	err := c.List(ctx, supplyChain)
-	if err != nil {
+	if err := c.List(ctx, supplyChain); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Add autocompletion func for `--type` flag. 

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #360 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Modified OOTB supply chain to have different selectors besides `web`, `server`, `worker` and showed also the custom ones. 

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
