### PR TITLE
Add max log requests for stern tailer

### DIFF
--- a/pkg/cli-runtime/logs/stern.go
+++ b/pkg/cli-runtime/logs/stern.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"text/template"
@@ -79,8 +80,7 @@ func (s *SternTailer) Tail(ctx context.Context, c *cli.Config, namespace string,
 		LabelSelector:  selector,
 		ContainerQuery: containerQuery,
 		ContainerStates: []stern.ContainerState{
-			stern.RUNNING,
-			stern.TERMINATED,
+			stern.ALL_STATES,
 		},
 		InitContainers: true,
 		Since:          since,
@@ -89,10 +89,11 @@ func (s *SternTailer) Tail(ctx context.Context, c *cli.Config, namespace string,
 		PodQuery:      regexp.MustCompile(""),
 		FieldSelector: fields.Everything(),
 
-		Template: template,
-		Out:      c.Stdout,
-		ErrOut:   c.Stderr,
-		Follow:   true,
+		Template:       template,
+		Out:            c.Stdout,
+		ErrOut:         c.Stderr,
+		Follow:         true,
+		MaxLogRequests: math.MaxInt16, // 32767
 	}
 
 	return stern.Run(ctx, &configStern)


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it

With Stern new version ([v1.24.0](https://github.com/stern/stern/releases/tag/v1.24.0)), a new flag was introduced to decide which is the maximum number of concurrent requests. In Apps Plugin code, it never gets to have a default number other than 0, that's why, if not specified in Stern configuration, logs would never appear since there weren't any allowed logs to show.
A number of the maximum Int16 (32767) was set as the max log requests for Stern, which means there can be up to that amount of pods logging at the same time for Apps Plugin `workload tail` or `workload create/update/apply --tail` to work.

Another change introduced in Stern was the `ALL_STATES` option for containers state filter. It was also added in Apps Plugin so all containers are shown (`running,waiting,terminated`).

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #519 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Created different workloads with `--tail` option to check that is logging.

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
