### PR TITLE
fix: handle 2xx status as healthy lsp

### DIFF
--- a/pkg/commands/lsp/lsp.go
+++ b/pkg/commands/lsp/lsp.go
@@ -113,8 +113,8 @@ func getStatusFromLSPResponse(r lspResponse) (lsp.HealthStatus, error) {
 	}
 
 	if s, err := strconv.Atoi(r.StatusCode); err == nil {
-		switch s {
-		case http.StatusOK:
+		switch {
+		case s >= http.StatusOK && s < http.StatusMultipleChoices:
 			return lsp.HealthStatus{
 				UserHasPermission:     true,
 				Reachable:             true,

--- a/pkg/commands/lsp/lsp_test.go
+++ b/pkg/commands/lsp/lsp_test.go
@@ -376,7 +376,7 @@ func Test_getStatusFromLSPResponse(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "200_OK",
+			name: "200 OK",
 			args: args{
 				r: lspResponse{
 					StatusCode: strconv.Itoa(http.StatusOK),
@@ -389,6 +389,36 @@ func Test_getStatusFromLSPResponse(t *testing.T) {
 				UpstreamAuthenticated: true,
 				OverallHealth:         true,
 				Message:               "All health checks passed",
+			},
+		},
+		{
+			name: "204 No Content",
+			args: args{
+				r: lspResponse{
+					StatusCode: strconv.Itoa(http.StatusNoContent),
+					Message:    msg,
+				},
+			},
+			want: lsp.HealthStatus{
+				UserHasPermission:     true,
+				Reachable:             true,
+				UpstreamAuthenticated: true,
+				OverallHealth:         true,
+				Message:               "All health checks passed",
+			},
+		},
+		{
+			name: "302 Found",
+			args: args{
+				r: lspResponse{
+					StatusCode: strconv.Itoa(http.StatusFound),
+					Message:    msg,
+				},
+			},
+			want: lsp.HealthStatus{
+				UserHasPermission: true,
+				Reachable:         true,
+				Message:           respMsg,
 			},
 		},
 		{


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it

Although in TAP 1.6+, LSP will be provisioned by default on TAP iterate clusters, we can’t assume developers will always be pointing to a TAP env where LSP exists or is running/healthy.

This PR fixes the LSP health response validation to take all the 2xx HTTP codes as a healthy answer

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #523 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
