### PR TITLE
feat: Check LSP health when create/update a workload

### DIFF
--- a/pkg/commands/workload_apply.go
+++ b/pkg/commands/workload_apply.go
@@ -151,6 +151,12 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 		return nil
 	}
 
+	if opts.useLSP(currentWorkload) {
+		if err := checkLSPHealth(ctx, c); err != nil {
+			return err
+		}
+	}
+
 	if err := opts.PublishLocalSource(ctx, c, currentWorkload, workload, shouldPrint); err != nil {
 		return err
 	}

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -18,8 +18,11 @@ package commands_test
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	runtm "runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cli "github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime"
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/logs"
@@ -174,6 +178,14 @@ func TestWorkloadApplyCommand(t *testing.T) {
 			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 				d.Name(defaultNamespace)
 			}),
+	}
+
+	respCreator := func(status int, body string) *http.Response {
+		return &http.Response{
+			Status:     http.StatusText(status),
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
 	}
 
 	table := clitesting.CommandTestSuite{
@@ -7123,6 +7135,466 @@ To get status: "tanzu apps workload get spring-petclinic"
 					}),
 			},
 			ShouldError: true,
+		},
+		{
+			Name:                "create from local source using lsp",
+			Skip:                runtm.GOOS == "windows",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "200", "message": "any ignored message"}`)),
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							apis.WorkloadTypeLabelName: "web",
+						},
+						Annotations: map[string]string{
+							"local-source-proxy.apps.tanzu.vmware.com": ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &v1alpha1.Source{
+							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+Publishing source in "%s" to "local-source-proxy.tap-local-source-system.svc.cluster.local/source:default-my-workload"...
+📥 Published source
+
+🔎 Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  annotations:
+      6 + |    local-source-proxy.apps.tanzu.vmware.com: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+      7 + |  labels:
+      8 + |    apps.tanzu.vmware.com/workload-type: web
+      9 + |  name: my-workload
+     10 + |  namespace: default
+     11 + |spec:
+     12 + |  source:
+     13 + |    image: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+👍 Created workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`, localSource),
+		},
+		{
+			Name:                "create from local source using lsp with 204 response",
+			Skip:                runtm.GOOS == "windows",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "204"}`)),
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							apis.WorkloadTypeLabelName: "web",
+						},
+						Annotations: map[string]string{
+							"local-source-proxy.apps.tanzu.vmware.com": ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &v1alpha1.Source{
+							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+Publishing source in "%s" to "local-source-proxy.tap-local-source-system.svc.cluster.local/source:default-my-workload"...
+📥 Published source
+
+🔎 Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  annotations:
+      6 + |    local-source-proxy.apps.tanzu.vmware.com: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+      7 + |  labels:
+      8 + |    apps.tanzu.vmware.com/workload-type: web
+      9 + |  name: my-workload
+     10 + |  namespace: default
+     11 + |spec:
+     12 + |  source:
+     13 + |    image: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+👍 Created workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`, localSource),
+		},
+		{
+			Name:                "create from local source using lsp with redirect registry error",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "302", "message": "Registry moved found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry moved found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with no upstream auth",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "401", "message": "401 Status user UNAUTHORIZED for registry"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- 401 Status user UNAUTHORIZED for registry"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with not found registry error",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "404", "message": "Registry not found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry not found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with internal error server registry error",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "500", "message": "Registry internal error"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry internal error"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with redirect response",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusFound, `{"message": "302 Status Found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: Local source proxy was moved and is not reachable in the defined url.\nErrors:\n- 302 Status Found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with no user permission",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusUnauthorized, `{"message": "401 Status Unauthorized"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: The current user does not have permission to access the local source proxy.\nErrors:\n- 401 Status Unauthorized"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with no found error",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusNotFound, `{"message": "404 Status Not Found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nError: Local source proxy is not installed on the cluster.\nErrors:\n- 404 Status Not Found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:         "create from local source using lsp with transport error",
+			Args:         []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: givenNamespaceDefault,
+			ShouldError:  true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "client transport not provided"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp",
+			Skip: runtm.GOOS == "windows",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "200", "message": "any ignored message"}`)),
+			ExpectUpdates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							apis.WorkloadTypeLabelName: "web",
+						},
+						Annotations: map[string]string{
+							"local-source-proxy.apps.tanzu.vmware.com": ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &v1alpha1.Source{
+							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+Publishing source in "%s" to "local-source-proxy.tap-local-source-system.svc.cluster.local/source:default-my-workload"...
+📥 Published source
+
+🔎 Update workload:
+...
+  2,  2   |apiVersion: carto.run/v1alpha1
+  3,  3   |kind: Workload
+  4,  4   |metadata:
+  5,  5   |  annotations:
+  6     - |    local-source-proxy.apps.tanzu.vmware.com: my-old-image
+      6 + |    local-source-proxy.apps.tanzu.vmware.com: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+  7,  7   |  labels:
+  8,  8   |    apps.tanzu.vmware.com/workload-type: web
+  9,  9   |  name: my-workload
+ 10, 10   |  namespace: default
+ 11     - |spec: {}
+     11 + |spec:
+     12 + |  source:
+     13 + |    image: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+👍 Updated workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`, localSource),
+		},
+		{
+			Name: "update from local source using lsp with status 204",
+			Skip: runtm.GOOS == "windows",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "204"}`)),
+			ExpectUpdates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							apis.WorkloadTypeLabelName: "web",
+						},
+						Annotations: map[string]string{
+							"local-source-proxy.apps.tanzu.vmware.com": ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &v1alpha1.Source{
+							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+Publishing source in "%s" to "local-source-proxy.tap-local-source-system.svc.cluster.local/source:default-my-workload"...
+📥 Published source
+
+🔎 Update workload:
+...
+  2,  2   |apiVersion: carto.run/v1alpha1
+  3,  3   |kind: Workload
+  4,  4   |metadata:
+  5,  5   |  annotations:
+  6     - |    local-source-proxy.apps.tanzu.vmware.com: my-old-image
+      6 + |    local-source-proxy.apps.tanzu.vmware.com: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+  7,  7   |  labels:
+  8,  8   |    apps.tanzu.vmware.com/workload-type: web
+  9,  9   |  name: my-workload
+ 10, 10   |  namespace: default
+ 11     - |spec: {}
+     11 + |spec:
+     12 + |  source:
+     13 + |    image: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+👍 Updated workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`, localSource),
+		},
+		{
+			Name: "update from local source using lsp with redirect registry error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "302", "message": "Registry moved found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry moved found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with no upstream auth",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "401", "message": "401 Status user UNAUTHORIZED for registry"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- 401 Status user UNAUTHORIZED for registry"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with not found registry error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "404", "message": "Registry not found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry not found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with internal error server registry error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "500", "message": "Registry internal error"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry internal error"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with redirect response",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusFound, `{"message": "302 Status Found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: Local source proxy was moved and is not reachable in the defined url.\nErrors:\n- 302 Status Found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with no user permission",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusUnauthorized, `{"message": "401 Status Unauthorized"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: The current user does not have permission to access the local source proxy.\nErrors:\n- 401 Status Unauthorized"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with no found error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusNotFound, `{"message": "404 Status Not Found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nError: Local source proxy is not installed on the cluster.\nErrors:\n- 404 Status Not Found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with transport error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			ShouldError: true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "client transport not provided"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
 		},
 	}
 

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -7155,7 +7155,7 @@ To get status: "tanzu apps workload get spring-petclinic"
 						},
 					},
 					Spec: cartov1alpha1.WorkloadSpec{
-						Source: &v1alpha1.Source{
+						Source: &cartov1alpha1.Source{
 							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
 						},
 					},
@@ -7205,7 +7205,7 @@ To get status: "tanzu apps workload get my-workload"
 						},
 					},
 					Spec: cartov1alpha1.WorkloadSpec{
-						Source: &v1alpha1.Source{
+						Source: &cartov1alpha1.Source{
 							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
 						},
 					},
@@ -7420,7 +7420,7 @@ To get status: "tanzu apps workload get my-workload"
 						},
 					},
 					Spec: cartov1alpha1.WorkloadSpec{
-						Source: &v1alpha1.Source{
+						Source: &cartov1alpha1.Source{
 							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
 						},
 					},

--- a/pkg/commands/workload_create.go
+++ b/pkg/commands/workload_create.go
@@ -101,6 +101,13 @@ func (opts *WorkloadCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	}
 
 	var okToCreate bool
+
+	if opts.useLSP(nil) {
+		if err := checkLSPHealth(ctx, c); err != nil {
+			return err
+		}
+	}
+
 	shouldPrint := opts.Output == "" || (opts.Output != "" && !opts.Yes)
 	if err := opts.PublishLocalSource(ctx, c, nil, workload, shouldPrint); err != nil {
 		return err

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -19,8 +19,12 @@ package commands_test
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
 	runtm "runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cli "github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime"
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/logs"
@@ -94,6 +99,7 @@ func TestWorkloadCreateOptionsValidate(t *testing.T) {
 }
 
 func TestWorkloadCreateCommand(t *testing.T) {
+	localSource := filepath.Join("testdata", "local-source")
 	defaultNamespace := "default"
 	workloadName := "my-workload"
 	gitRepo := "https://example.com/repo.git"
@@ -111,6 +117,14 @@ func TestWorkloadCreateCommand(t *testing.T) {
 			MetadataDie(func(d *diemetav1.ObjectMetaDie) {
 				d.Name(defaultNamespace)
 			}),
+	}
+
+	respCreator := func(status int, body string) *http.Response {
+		return &http.Response{
+			Status:     http.StatusText(status),
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
 	}
 
 	table := clitesting.CommandTestSuite{
@@ -1979,6 +1993,209 @@ Error: failed to create watcher
 	}
 }
 `, clitesting.ToInteractTerminal("❓ Do you want to create this workload? [yN]: y"), workloadName),
+		},
+		{
+			Name:                "create from local source using lsp",
+			Skip:                runtm.GOOS == "windows",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "200", "message": "any ignored message"}`)),
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							apis.WorkloadTypeLabelName: "web",
+						},
+						Annotations: map[string]string{
+							"local-source-proxy.apps.tanzu.vmware.com": ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &v1alpha1.Source{
+							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+Publishing source in "%s" to "local-source-proxy.tap-local-source-system.svc.cluster.local/source:default-my-workload"...
+📥 Published source
+
+🔎 Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  annotations:
+      6 + |    local-source-proxy.apps.tanzu.vmware.com: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+      7 + |  labels:
+      8 + |    apps.tanzu.vmware.com/workload-type: web
+      9 + |  name: my-workload
+     10 + |  namespace: default
+     11 + |spec:
+     12 + |  source:
+     13 + |    image: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+👍 Created workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`, localSource),
+		},
+		{
+			Name:                "create from local source using lsp with 204 response",
+			Skip:                runtm.GOOS == "windows",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "204"}`)),
+			ExpectCreates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							apis.WorkloadTypeLabelName: "web",
+						},
+						Annotations: map[string]string{
+							"local-source-proxy.apps.tanzu.vmware.com": ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &v1alpha1.Source{
+							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+Publishing source in "%s" to "local-source-proxy.tap-local-source-system.svc.cluster.local/source:default-my-workload"...
+📥 Published source
+
+🔎 Create workload:
+      1 + |---
+      2 + |apiVersion: carto.run/v1alpha1
+      3 + |kind: Workload
+      4 + |metadata:
+      5 + |  annotations:
+      6 + |    local-source-proxy.apps.tanzu.vmware.com: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+      7 + |  labels:
+      8 + |    apps.tanzu.vmware.com/workload-type: web
+      9 + |  name: my-workload
+     10 + |  namespace: default
+     11 + |spec:
+     12 + |  source:
+     13 + |    image: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+👍 Created workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`, localSource),
+		},
+		{
+			Name:                "create from local source using lsp with redirect registry error",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "302", "message": "Registry moved found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry moved found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with no upstream auth",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "401", "message": "401 Status user UNAUTHORIZED for registry"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- 401 Status user UNAUTHORIZED for registry"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with not found registry error",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "404", "message": "Registry not found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry not found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with internal error server registry error",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "500", "message": "Registry internal error"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry internal error"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with redirect response",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusFound, `{"message": "302 Status Found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: Local source proxy was moved and is not reachable in the defined url.\nErrors:\n- 302 Status Found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with no user permission",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusUnauthorized, `{"message": "401 Status Unauthorized"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: The current user does not have permission to access the local source proxy.\nErrors:\n- 401 Status Unauthorized"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:                "create from local source using lsp with no found error",
+			Args:                []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects:        givenNamespaceDefault,
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusNotFound, `{"message": "404 Status Not Found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nError: Local source proxy is not installed on the cluster.\nErrors:\n- 404 Status Not Found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name:         "create from local source using lsp with transport error",
+			Args:         []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: givenNamespaceDefault,
+			ShouldError:  true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "client transport not provided"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
 		},
 	}
 

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -43,7 +43,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis"
-	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cli "github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime"
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/logs"
@@ -2013,7 +2012,7 @@ Error: failed to create watcher
 						},
 					},
 					Spec: cartov1alpha1.WorkloadSpec{
-						Source: &v1alpha1.Source{
+						Source: &cartov1alpha1.Source{
 							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
 						},
 					},
@@ -2063,7 +2062,7 @@ To get status: "tanzu apps workload get my-workload"
 						},
 					},
 					Spec: cartov1alpha1.WorkloadSpec{
-						Source: &v1alpha1.Source{
+						Source: &cartov1alpha1.Source{
 							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
 						},
 					},

--- a/pkg/commands/workload_update.go
+++ b/pkg/commands/workload_update.go
@@ -124,6 +124,12 @@ func (opts *WorkloadUpdateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		return nil
 	}
 
+	if opts.useLSP(currentWorkload) {
+		if err := checkLSPHealth(ctx, c); err != nil {
+			return err
+		}
+	}
+
 	// If user answers yes to survey prompt about publishing source, continue with workload update
 	if err := opts.PublishLocalSource(ctx, c, currentWorkload, workload, true); err != nil {
 		return err

--- a/pkg/commands/workload_update_test.go
+++ b/pkg/commands/workload_update_test.go
@@ -19,7 +19,10 @@ package commands_test
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	runtm "runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis"
+	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cli "github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime"
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/logs"
@@ -115,6 +119,13 @@ func TestWorkloadUpdateCommand(t *testing.T) {
 			d.Name("spring-petclinic")
 			d.Namespace(defaultNamespace)
 		})
+	respCreator := func(status int, body string) *http.Response {
+		return &http.Response{
+			Status:     http.StatusText(status),
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
+	}
 	table := clitesting.CommandTestSuite{
 		{
 			Name:        "invalid args",
@@ -1460,6 +1471,267 @@ To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
 To get status: "tanzu apps workload get my-workload"
 
 `,
+		},
+		{
+			Name: "update from local source using lsp",
+			Skip: runtm.GOOS == "windows",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "200", "message": "any ignored message"}`)),
+			ExpectUpdates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							apis.WorkloadTypeLabelName: "web",
+						},
+						Annotations: map[string]string{
+							"local-source-proxy.apps.tanzu.vmware.com": ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &v1alpha1.Source{
+							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+❗ WARNING: the update command has been deprecated and will be removed in a future update. Please use "tanzu apps workload apply" instead.
+
+Publishing source in "%s" to "local-source-proxy.tap-local-source-system.svc.cluster.local/source:default-my-workload"...
+📥 Published source
+
+🔎 Update workload:
+...
+  2,  2   |apiVersion: carto.run/v1alpha1
+  3,  3   |kind: Workload
+  4,  4   |metadata:
+  5,  5   |  annotations:
+  6     - |    local-source-proxy.apps.tanzu.vmware.com: my-old-image
+      6 + |    local-source-proxy.apps.tanzu.vmware.com: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+  7,  7   |  labels:
+  8,  8   |    apps.tanzu.vmware.com/workload-type: web
+  9,  9   |  name: my-workload
+ 10, 10   |  namespace: default
+ 11     - |spec: {}
+     11 + |spec:
+     12 + |  source:
+     13 + |    image: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+👍 Updated workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`, localSource),
+		},
+		{
+			Name: "update from local source using lsp with status 204",
+			Skip: runtm.GOOS == "windows",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "204"}`)),
+			ExpectUpdates: []client.Object{
+				&cartov1alpha1.Workload{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      workloadName,
+						Labels: map[string]string{
+							apis.WorkloadTypeLabelName: "web",
+						},
+						Annotations: map[string]string{
+							"local-source-proxy.apps.tanzu.vmware.com": ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+					Spec: cartov1alpha1.WorkloadSpec{
+						Source: &v1alpha1.Source{
+							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
+						},
+					},
+				},
+			},
+			ExpectOutput: fmt.Sprintf(`
+❗ WARNING: the update command has been deprecated and will be removed in a future update. Please use "tanzu apps workload apply" instead.
+
+Publishing source in "%s" to "local-source-proxy.tap-local-source-system.svc.cluster.local/source:default-my-workload"...
+📥 Published source
+
+🔎 Update workload:
+...
+  2,  2   |apiVersion: carto.run/v1alpha1
+  3,  3   |kind: Workload
+  4,  4   |metadata:
+  5,  5   |  annotations:
+  6     - |    local-source-proxy.apps.tanzu.vmware.com: my-old-image
+      6 + |    local-source-proxy.apps.tanzu.vmware.com: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+  7,  7   |  labels:
+  8,  8   |    apps.tanzu.vmware.com/workload-type: web
+  9,  9   |  name: my-workload
+ 10, 10   |  namespace: default
+ 11     - |spec: {}
+     11 + |spec:
+     12 + |  source:
+     13 + |    image: :default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652
+👍 Updated workload "my-workload"
+
+To see logs:   "tanzu apps workload tail my-workload --timestamp --since 1h"
+To get status: "tanzu apps workload get my-workload"
+
+`, localSource),
+		},
+		{
+			Name: "update from local source using lsp with redirect registry error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "302", "message": "Registry moved found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry moved found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with no upstream auth",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "401", "message": "401 Status user UNAUTHORIZED for registry"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- 401 Status user UNAUTHORIZED for registry"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with not found registry error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "404", "message": "Registry not found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry not found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with internal error server registry error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "500", "message": "Registry internal error"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry internal error"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with redirect response",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusFound, `{"message": "302 Status Found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: Local source proxy was moved and is not reachable in the defined url.\nErrors:\n- 302 Status Found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with no user permission",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusUnauthorized, `{"message": "401 Status Unauthorized"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: The current user does not have permission to access the local source proxy.\nErrors:\n- 401 Status Unauthorized"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with no found error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusNotFound, `{"message": "404 Status Not Found"}`)),
+			ShouldError:         true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nError: Local source proxy is not installed on the cluster.\nErrors:\n- 404 Status Not Found"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
+		},
+		{
+			Name: "update from local source using lsp with transport error",
+			Args: []string{workloadName, flags.LocalPathFlagName, localSource, flags.YesFlagName},
+			GivenObjects: []client.Object{
+				parent.
+					MetadataDie(func(d *diemetav1.ObjectMetaDie) {
+						d.Annotations(map[string]string{apis.LocalSourceProxyAnnotationName: "my-old-image"})
+					}),
+			},
+			ShouldError: true,
+			Verify: func(t *testing.T, output string, err error) {
+				msg := "client transport not provided"
+				if err.Error() != msg {
+					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
+				}
+			},
 		},
 	}
 

--- a/pkg/commands/workload_update_test.go
+++ b/pkg/commands/workload_update_test.go
@@ -42,7 +42,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis"
-	"github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cartov1alpha1 "github.com/vmware-tanzu/apps-cli-plugin/pkg/apis/cartographer/v1alpha1"
 	cli "github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime"
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/cli-runtime/logs"
@@ -1496,7 +1495,7 @@ To get status: "tanzu apps workload get my-workload"
 						},
 					},
 					Spec: cartov1alpha1.WorkloadSpec{
-						Source: &v1alpha1.Source{
+						Source: &cartov1alpha1.Source{
 							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
 						},
 					},
@@ -1555,7 +1554,7 @@ To get status: "tanzu apps workload get my-workload"
 						},
 					},
 					Spec: cartov1alpha1.WorkloadSpec{
-						Source: &v1alpha1.Source{
+						Source: &cartov1alpha1.Source{
 							Image: ":default-my-workload@sha256:111d543b7736846f502387eed53be08c5ceb0a6010faaaf043409702074cf652",
 						},
 					},


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it

When creating a workload using the local source proxy or updating a workload created using the local source proxy, the health is called before the local source start being updated.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #523 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Created a workload with using local source proxy and then editing it
changing the secrets on lsp to fail 

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
