### PR TITLE
Updates the LSP Error messages in the health and workload output

### DIFF
--- a/pkg/commands/localsourceproxy_health_test.go
+++ b/pkg/commands/localsourceproxy_health_test.go
@@ -136,7 +136,7 @@ upstream_authenticated: false
 overall_health: false
 message: |-
   The current user does not have permission to access the local source proxy.
-  Errors:
+  Messages:
   - 401 Status Unauthorized
 `,
 		},
@@ -151,7 +151,7 @@ upstream_authenticated: false
 overall_health: false
 message: |-
   Local source proxy was unable to authenticate against the target registry.
-  Errors:
+  Messages:
   - 401 Status user UNAUTHORIZED for registry
 `,
 		},

--- a/pkg/commands/lsp/lsp.go
+++ b/pkg/commands/lsp/lsp.go
@@ -30,7 +30,7 @@ import (
 	"github.com/vmware-tanzu/apps-cli-plugin/pkg/source"
 )
 
-const errFormat = "%s\nErrors:\n- %s"
+const errFormat = "%s\nMessages:\n- %s"
 
 type lspResponse struct {
 	Message    string `json:"message"`

--- a/pkg/commands/lsp/lsp_test.go
+++ b/pkg/commands/lsp/lsp_test.go
@@ -100,7 +100,7 @@ func TestGetStatus(t *testing.T) {
 				c:   getConfig(getResponse(http.StatusUnauthorized, (`{"message": "403 Forbidden"}`))),
 			},
 			want: lsp.HealthStatus{
-				Message: "The current user does not have permission to access the local source proxy.\nErrors:\n- 403 Forbidden",
+				Message: "The current user does not have permission to access the local source proxy.\nMessages:\n- 403 Forbidden",
 			},
 		},
 		{
@@ -110,7 +110,7 @@ func TestGetStatus(t *testing.T) {
 				c:   getConfig(getResponse(http.StatusUnauthorized, (`{"message": "401 Unauthorized"}`))),
 			},
 			want: lsp.HealthStatus{
-				Message: "The current user does not have permission to access the local source proxy.\nErrors:\n- 401 Unauthorized",
+				Message: "The current user does not have permission to access the local source proxy.\nMessages:\n- 401 Unauthorized",
 			},
 		},
 		{
@@ -122,7 +122,7 @@ func TestGetStatus(t *testing.T) {
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
 				Reachable:         true,
-				Message:           "Local source proxy is not healthy.\nErrors:\n- 500 Internal Server Error",
+				Message:           "Local source proxy is not healthy.\nMessages:\n- 500 Internal Server Error",
 			},
 		},
 		{
@@ -134,7 +134,7 @@ func TestGetStatus(t *testing.T) {
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
 				Reachable:         true,
-				Message:           "Local source proxy is not healthy.\nErrors:\n- 504 GatewayTimeout",
+				Message:           "Local source proxy is not healthy.\nMessages:\n- 504 GatewayTimeout",
 			},
 		},
 		{
@@ -145,7 +145,7 @@ func TestGetStatus(t *testing.T) {
 			},
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
-				Message:           "Local source proxy is not healthy.\nErrors:\n- 503 Service Unavailable",
+				Message:           "Local source proxy is not healthy.\nMessages:\n- 503 Service Unavailable",
 			},
 		},
 		{
@@ -156,7 +156,7 @@ func TestGetStatus(t *testing.T) {
 			},
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
-				Message:           "Local source proxy is not installed on the cluster.\nErrors:\n- 404 Not Found",
+				Message:           "Local source proxy is not installed on the cluster.\nMessages:\n- 404 Not Found",
 			},
 		},
 
@@ -169,7 +169,7 @@ func TestGetStatus(t *testing.T) {
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
 				Reachable:         true,
-				Message:           "Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Found",
+				Message:           "Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Found",
 			},
 		},
 		{
@@ -181,7 +181,7 @@ func TestGetStatus(t *testing.T) {
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
 				Reachable:         true,
-				Message:           "Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Bad Request",
+				Message:           "Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Bad Request",
 			},
 		},
 		{
@@ -193,7 +193,7 @@ func TestGetStatus(t *testing.T) {
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
 				Reachable:         true,
-				Message:           "Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Unauthorized",
+				Message:           "Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Unauthorized",
 			},
 		},
 		{
@@ -205,7 +205,7 @@ func TestGetStatus(t *testing.T) {
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
 				Reachable:         true,
-				Message:           "Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Forbidden",
+				Message:           "Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Forbidden",
 			},
 		},
 		{
@@ -217,7 +217,7 @@ func TestGetStatus(t *testing.T) {
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
 				Reachable:         true,
-				Message:           "Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Not Found",
+				Message:           "Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Not Found",
 			},
 		},
 		{
@@ -229,7 +229,7 @@ func TestGetStatus(t *testing.T) {
 			want: lsp.HealthStatus{
 				UserHasPermission: true,
 				Reachable:         true,
-				Message:           "Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Internal Server Error",
+				Message:           "Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Internal Server Error",
 			},
 		},
 	}
@@ -273,7 +273,7 @@ func Test_checkRequestResponseCode(t *testing.T) {
 			},
 			want: &lsp.HealthStatus{
 				Message: `The current user does not have permission to access the local source proxy.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -285,7 +285,7 @@ Errors:
 			},
 			want: &lsp.HealthStatus{
 				Message: `The current user does not have permission to access the local source proxy.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -299,7 +299,7 @@ Errors:
 				UserHasPermission: true,
 				Reachable:         true,
 				Message: `Local source proxy is not healthy.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -313,7 +313,7 @@ Errors:
 				UserHasPermission: true,
 				Reachable:         true,
 				Message: `Local source proxy is not healthy.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -327,7 +327,7 @@ Errors:
 				UserHasPermission: true,
 				Reachable:         true,
 				Message: `Local source proxy is not healthy.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -340,7 +340,7 @@ Errors:
 			want: &lsp.HealthStatus{
 				UserHasPermission: true,
 				Message: `Local source proxy is not healthy.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -353,7 +353,7 @@ Errors:
 			want: &lsp.HealthStatus{
 				UserHasPermission: true,
 				Message: `Local source proxy is not installed on the cluster.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -365,7 +365,7 @@ Errors:
 			},
 			want: &lsp.HealthStatus{
 				Message: `The request is not valid for the query the health of the ocal source proxy.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -377,7 +377,7 @@ Errors:
 			},
 			want: &lsp.HealthStatus{
 				Message: `Local source proxy was moved and is not reachable in the defined url.
-Errors:
+Messages:
 - my cool message`,
 			},
 		},
@@ -394,7 +394,7 @@ Errors:
 
 func Test_getStatusFromLSPResponse(t *testing.T) {
 	msg := "my cool message"
-	respMsg := "Local source proxy was unable to authenticate against the target registry.\nErrors:\n- my cool message"
+	respMsg := "Local source proxy was unable to authenticate against the target registry.\nMessages:\n- my cool message"
 	type args struct {
 		r lspResponse
 	}

--- a/pkg/commands/workload.go
+++ b/pkg/commands/workload.go
@@ -910,11 +910,11 @@ func checkLSPHealth(ctx context.Context, c *cli.Config) error {
 	} else {
 		switch {
 		case !s.UserHasPermission:
-			return fmt.Errorf("Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: %s", s.Message)
+			return fmt.Errorf("Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nReason: %s", s.Message)
 		case !s.Reachable:
-			return fmt.Errorf("Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nError: %s", s.Message)
+			return fmt.Errorf("Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nReason: %s", s.Message)
 		case !s.UpstreamAuthenticated:
-			return fmt.Errorf("Local source proxy failed to upload source to the repository\nError: %s", s.Message)
+			return fmt.Errorf("Local source proxy failed to upload source to the repository\nReason: %s", s.Message)
 		}
 	}
 	return nil

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -7973,7 +7973,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "302", "message": "Registry moved found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry moved found"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry moved found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -7986,7 +7986,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "401", "message": "401 Status user UNAUTHORIZED for registry"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- 401 Status user UNAUTHORIZED for registry"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- 401 Status user UNAUTHORIZED for registry"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -7999,7 +7999,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "404", "message": "Registry not found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry not found"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry not found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8012,7 +8012,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "500", "message": "Registry internal error"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry internal error"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry internal error"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8025,7 +8025,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusFound, `{"message": "302 Status Found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: Local source proxy was moved and is not reachable in the defined url.\nErrors:\n- 302 Status Found"
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nReason: Local source proxy was moved and is not reachable in the defined url.\nMessages:\n- 302 Status Found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8038,7 +8038,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusUnauthorized, `{"message": "401 Status Unauthorized"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: The current user does not have permission to access the local source proxy.\nErrors:\n- 401 Status Unauthorized"
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nReason: The current user does not have permission to access the local source proxy.\nMessages:\n- 401 Status Unauthorized"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8051,7 +8051,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusNotFound, `{"message": "404 Status Not Found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nError: Local source proxy is not installed on the cluster.\nErrors:\n- 404 Status Not Found"
+				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nReason: Local source proxy is not installed on the cluster.\nMessages:\n- 404 Status Not Found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8761,7 +8761,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "302", "message": "Registry moved found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry moved found"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry moved found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8779,7 +8779,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "401", "message": "401 Status user UNAUTHORIZED for registry"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- 401 Status user UNAUTHORIZED for registry"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- 401 Status user UNAUTHORIZED for registry"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8797,7 +8797,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "404", "message": "Registry not found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry not found"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry not found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8815,7 +8815,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "500", "message": "Registry internal error"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry internal error"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry internal error"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8833,7 +8833,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusFound, `{"message": "302 Status Found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: Local source proxy was moved and is not reachable in the defined url.\nErrors:\n- 302 Status Found"
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nReason: Local source proxy was moved and is not reachable in the defined url.\nMessages:\n- 302 Status Found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8851,7 +8851,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusUnauthorized, `{"message": "401 Status Unauthorized"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: The current user does not have permission to access the local source proxy.\nErrors:\n- 401 Status Unauthorized"
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nReason: The current user does not have permission to access the local source proxy.\nMessages:\n- 401 Status Unauthorized"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -8869,7 +8869,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusNotFound, `{"message": "404 Status Not Found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nError: Local source proxy is not installed on the cluster.\nErrors:\n- 404 Status Not Found"
+				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nReason: Local source proxy is not installed on the cluster.\nMessages:\n- 404 Status Not Found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -2236,7 +2236,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "302", "message": "Registry moved found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry moved found"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry moved found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -2249,7 +2249,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "401", "message": "401 Status user UNAUTHORIZED for registry"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- 401 Status user UNAUTHORIZED for registry"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- 401 Status user UNAUTHORIZED for registry"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -2262,7 +2262,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "404", "message": "Registry not found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry not found"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry not found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -2275,7 +2275,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusOK, `{"statuscode": "500", "message": "Registry internal error"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy failed to upload source to the repository\nError: Local source proxy was unable to authenticate against the target registry.\nErrors:\n- Registry internal error"
+				msg := "Local source proxy failed to upload source to the repository\nReason: Local source proxy was unable to authenticate against the target registry.\nMessages:\n- Registry internal error"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -2288,7 +2288,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusFound, `{"message": "302 Status Found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: Local source proxy was moved and is not reachable in the defined url.\nErrors:\n- 302 Status Found"
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nReason: Local source proxy was moved and is not reachable in the defined url.\nMessages:\n- 302 Status Found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -2301,7 +2301,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusUnauthorized, `{"message": "401 Status Unauthorized"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nError: The current user does not have permission to access the local source proxy.\nErrors:\n- 401 Status Unauthorized"
+				msg := "Either Local Source Proxy is not installed on the Cluster or you don't have permissions to access it\nReason: The current user does not have permission to access the local source proxy.\nMessages:\n- 401 Status Unauthorized"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}
@@ -2314,7 +2314,7 @@ To get status: "tanzu apps workload get my-workload"
 			KubeConfigTransport: clitesting.NewFakeTransportFromResponse(respCreator(http.StatusNotFound, `{"message": "404 Status Not Found"}`, myWorkloadHeader)),
 			ShouldError:         true,
 			Verify: func(t *testing.T, output string, err error) {
-				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nError: Local source proxy is not installed on the cluster.\nErrors:\n- 404 Status Not Found"
+				msg := "Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag\nReason: Local source proxy is not installed on the cluster.\nMessages:\n- 404 Status Not Found"
 				if err.Error() != msg {
 					t.Errorf("Expected error to be %q but got %q", msg, err.Error())
 				}


### PR DESCRIPTION
…as worklaod apply and create output

Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
PR updates the workload apply and create output error message as well as` tanzu apps lsp health` command error output to display `Reasons` and `Messages` instead of `Error` and `Errors` respectively.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #550 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

Since the code for generating error messages based on response error codes are reused between tanzu apps workload commands as well as tanzu apps lsp health command, product agreed to change  the message that are common for both commands . 

Example :- 

lsp health command output 
```
user_has_permission: true
reachable: true
upstream_authenticated: false
overall_health: false
message: |-
  Local source proxy was unable to authenticate against the target registry.
  Errors:
  - GET https://gcr.io/v2/token?scope=repository:kshaheer-playground/lsp:pull,push&service=gcr.io: UNAUTHORIZED: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
```
 has been changed to 
 
```
user_has_permission: true
reachable: true
upstream_authenticated: false
overall_health: false
message: |-
  Local source proxy was unable to authenticate against the target registry.
  Messages:
  - GET https://gcr.io/v2/token?scope=repository:kshaheer-playground/lsp:pull,push&service=gcr.io: UNAUTHORIZED: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
```

Similarly Tanzu apps workload create and apply error output has been changed from 
```
Error: Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag
Error: Local source proxy is not installed on the cluster.
Errors:
- services "local-source-proxy" not found
```

to 

```
Error:  Local source proxy is not installed or the deployment is not healthy. Either install it or use --source-image flag
Reason: Local source proxy is not installed on the cluster.
Messages:
- services "local-source-proxy" not found
```
