### PR TITLE
feat: add delay time to prevent exit before supply chain is ready

### DIFF
--- a/docs/command-reference/tanzu_apps_workload_apply.md
+++ b/docs/command-reference/tanzu_apps_workload_apply.md
@@ -29,6 +29,7 @@ tanzu apps workload apply --file workload.yaml
   -a, --app name                       application name the workload is a part of
       --build-env "key=value" pair     build environment variables represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
       --debug                          put the workload in debug mode (--debug=false to deactivate)
+      --delay duration                 delay set to prevent premature exit before supply chain step completion when waiting/tailing (default 30s)
       --dry-run                        print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
   -e, --env "key=value" pair           environment variables represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
   -f, --file file path                 file path containing the description of a single workload, other flags are layered on top of this resource. Use value "-" to read from stdin

--- a/docs/command-reference/tanzu_apps_workload_create.md
+++ b/docs/command-reference/tanzu_apps_workload_create.md
@@ -31,6 +31,7 @@ tanzu apps workload create --file workload.yaml
   -a, --app name                       application name the workload is a part of
       --build-env "key=value" pair     build environment variables represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
       --debug                          put the workload in debug mode (--debug=false to deactivate)
+      --delay duration                 delay set to prevent premature exit before supply chain step completion when waiting/tailing (default 30s)
       --dry-run                        print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
   -e, --env "key=value" pair           environment variables represented as a "key=value" pair ("key-" to remove, flag can be used multiple times)
   -f, --file file path                 file path containing the description of a single workload, other flags are layered on top of this resource. Use value "-" to read from stdin

--- a/pkg/cli-runtime/wait/wait_test.go
+++ b/pkg/cli-runtime/wait/wait_test.go
@@ -133,7 +133,7 @@ func TestUntilReady(t *testing.T) {
 			done := make(chan error, 1)
 			defer close(done)
 			go func() {
-				done <- UntilCondition(ctx, fakeWithWatcher, types.NamespacedName{Name: test.resource.Name, Namespace: test.resource.Namespace}, &cartov1alpha1.WorkloadList{}, test.condFunc)
+				done <- UntilCondition(ctx, fakeWithWatcher, types.NamespacedName{Name: test.resource.Name, Namespace: test.resource.Namespace}, &cartov1alpha1.WorkloadList{}, test.condFunc, 0*time.Second)
 			}()
 
 			for _, r := range objs {

--- a/pkg/commands/workload_apply.go
+++ b/pkg/commands/workload_apply.go
@@ -225,7 +225,7 @@ func (opts *WorkloadApplyOptions) Exec(ctx context.Context, c *cli.Config) error
 				}
 			}
 
-			workers = append(workers, getReadyConditionWorker(c, workload))
+			workers = append(workers, getReadyConditionWorker(c, workload, opts.DelayTime))
 
 			if anyTail {
 				workers = append(workers, getTailWorker(c, workload, opts.TailTimestamps))

--- a/pkg/commands/workload_apply_test.go
+++ b/pkg/commands/workload_apply_test.go
@@ -350,7 +350,7 @@ status:
 		{
 			Name: "create - output yaml with wait",
 			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
-				flags.OutputFlagName, printer.OutputFormatYaml, flags.WaitFlagName, flags.YesFlagName},
+				flags.OutputFlagName, printer.OutputFormatYaml, flags.WaitFlagName, flags.YesFlagName, flags.DelayTimeFlagName, "0ns"},
 			GivenObjects: givenNamespaceDefault,
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
@@ -936,7 +936,7 @@ To get status: "tanzu apps workload get my-workload"
 		{
 			Name: "wait with timeout error",
 			Skip: runtm.GOOS == "windows",
-			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName, flags.WaitTimeoutFlagName, "1ns"},
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName, flags.WaitTimeoutFlagName, "1ns", flags.DelayTimeFlagName, "0ns"},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1011,7 +1011,7 @@ Error waiting for ready condition: timeout after 1ns waiting for "my-workload" t
 		},
 		{
 			Name: "create - successful wait for ready cond",
-			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName},
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName, flags.DelayTimeFlagName, "0ns"},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1203,7 +1203,7 @@ Workload "my-workload" is ready
 		},
 		{
 			Name: "create - watcher error",
-			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName},
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName, flags.DelayTimeFlagName, "0ns"},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				fakewatch := watchfakes.NewFakeWithWatch(true, config.Client, []watch.Event{})
 				ctx = watchhelper.WithWatcher(ctx, fakewatch)
@@ -1990,7 +1990,7 @@ Error: conflict updating workload, the object was modified by another user; plea
 		{
 			Name: "update - wait for ready condition - error with timeout",
 			Skip: runtm.GOOS == "windows",
-			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.WaitTimeoutFlagName, "1ns"},
+			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.WaitTimeoutFlagName, "1ns", flags.DelayTimeFlagName, "0ns"},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
@@ -2102,7 +2102,7 @@ Error waiting for ready condition: timeout after 1ns waiting for "my-workload" t
 		{
 			Name: "update - wait timeout when there is no transition time",
 			Skip: runtm.GOOS == "windows",
-			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.WaitTimeoutFlagName, "1ns"},
+			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.WaitTimeoutFlagName, "1ns", flags.DelayTimeFlagName, "0ns"},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
@@ -2209,7 +2209,7 @@ Error waiting for status change: timeout after 1ns waiting for "my-workload" to 
 		{
 			Name: "update - wait timeout when there is no ready cond",
 			Skip: runtm.GOOS == "windows",
-			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.WaitTimeoutFlagName, "1ns"},
+			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.WaitTimeoutFlagName, "1ns", flags.DelayTimeFlagName, "0ns"},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
@@ -2302,7 +2302,7 @@ Error waiting for status change: timeout after 1ns waiting for "my-workload" to 
 		{
 			Name: "update - wait for timestamp change error with timeout",
 			Skip: runtm.GOOS == "windows",
-			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.WaitTimeoutFlagName, "1ns"},
+			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.WaitTimeoutFlagName, "1ns", flags.DelayTimeFlagName, "0ns"},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
@@ -2412,7 +2412,7 @@ Error waiting for status change: timeout after 1ns waiting for "my-workload" to 
 		},
 		{
 			Name: "update - wait error for false condition",
-			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName},
+			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.DelayTimeFlagName, "0ns"},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
@@ -2523,7 +2523,7 @@ Error waiting for ready condition: Failed to become ready: a hopefully informati
 		},
 		{
 			Name: "update - successful wait for ready condition",
-			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName},
+			Args: []string{workloadName, flags.ServiceRefFlagName, "database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db", flags.WaitFlagName, flags.YesFlagName, flags.DelayTimeFlagName, "0ns"},
 			GivenObjects: []client.Object{
 				parent.
 					SpecDie(func(d *diecartov1alpha1.WorkloadSpecDie) {
@@ -5356,7 +5356,7 @@ status:
 			Name: "output workload after update in yaml format with wait error",
 			Args: []string{workloadName, flags.ServiceRefFlagName,
 				"database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db",
-				flags.OutputFlagName, printer.OutputFormatYml, flags.WaitFlagName},
+				flags.OutputFlagName, printer.OutputFormatYml, flags.WaitFlagName, flags.DelayTimeFlagName, "0ns"},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -5499,7 +5499,7 @@ status:
 			Name: "console interaction - output workload after update in yaml format with wait",
 			Args: []string{workloadName, flags.ServiceRefFlagName,
 				"database=services.tanzu.vmware.com/v1alpha1:PostgreSQL:my-prod-db",
-				flags.OutputFlagName, printer.OutputFormatYml, flags.WaitFlagName},
+				flags.OutputFlagName, printer.OutputFormatYml, flags.WaitFlagName, flags.DelayTimeFlagName, "0ns"},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/commands/workload_create.go
+++ b/pkg/commands/workload_create.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -144,7 +145,7 @@ func (opts *WorkloadCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		if opts.Wait || anyTail {
 			cli.PrintPrompt(shouldPrint, c.Infof, "Waiting for workload %q to become ready...\n", opts.Name)
 
-			workers = append(workers, getReadyConditionWorker(c, workload))
+			workers = append(workers, getReadyConditionWorker(c, workload, 0*time.Second))
 
 			if anyTail {
 				workers = append(workers, getTailWorker(c, workload, opts.TailTimestamps))

--- a/pkg/commands/workload_create_test.go
+++ b/pkg/commands/workload_create_test.go
@@ -185,7 +185,7 @@ status:
 		{
 			Name: "create - output yaml with wait",
 			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
-				flags.OutputFlagName, printer.OutputFormatYaml, flags.WaitFlagName, flags.YesFlagName},
+				flags.OutputFlagName, printer.OutputFormatYaml, flags.WaitFlagName, flags.YesFlagName, flags.DelayTimeFlagName, "0ns"},
 			GivenObjects: givenNamespaceDefault,
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
@@ -310,7 +310,7 @@ status:
 		},
 		{
 			Name: "wait error for false condition",
-			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName},
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName, flags.DelayTimeFlagName, "0ns"},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -463,7 +463,7 @@ Error waiting for ready condition: timeout after 1ns waiting for "my-workload" t
 		},
 		{
 			Name: "successful wait for ready cond",
-			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName},
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName, flags.DelayTimeFlagName, "0ns"},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				workload := &cartov1alpha1.Workload{
 					ObjectMeta: metav1.ObjectMeta{
@@ -756,7 +756,7 @@ Error: workload "default/my-workload" already exists
 		},
 		{
 			Name: "watcher error",
-			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName},
+			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch, flags.YesFlagName, flags.WaitFlagName, flags.DelayTimeFlagName, "0ns"},
 			Prepare: func(t *testing.T, ctx context.Context, config *cli.Config, tc *clitesting.CommandTestCase) (context.Context, error) {
 				fakewatch := watchfakes.NewFakeWithWatch(true, config.Client, []watch.Event{})
 				ctx = watchhelper.WithWatcher(ctx, fakewatch)
@@ -1901,7 +1901,7 @@ Error waiting for ready condition: failed to create watcher
 			Name:         "output workload after create in json format with wait error",
 			GivenObjects: givenNamespaceDefault,
 			Args: []string{workloadName, flags.GitRepoFlagName, gitRepo, flags.GitBranchFlagName, gitBranch,
-				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatJson, flags.WaitFlagName},
+				flags.TypeFlagName, "web", flags.OutputFlagName, printer.OutputFormatJson, flags.WaitFlagName, flags.DelayTimeFlagName, "0ns"},
 			WithConsoleInteractions: func(t *testing.T, c *expect.Console) {
 				c.ExpectString(clitesting.ToInteractTerminal("Do you want to create this workload? [yN]: "))
 				c.Send(clitesting.InteractInputLine("y"))

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -30,6 +30,7 @@ const (
 	ConfigFlagName           = "--config"
 	ContextFlagName          = cli.ContextFlagName
 	DebugFlagName            = "--debug"
+	DelayTimeFlagName        = "--delay"
 	DryRunFlagName           = "--dry-run"
 	EnvFlagName              = "--env"
 	ExportFlagName           = "--export"


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
This PR addresses use case when `workload apply` is used along with `--wait` and/or `--tail` command to update an existing workload - apps CLI considers transition between steps to being workload ready and exits. With this fix it waits (default `30s`) to let the intermittent step transition to ensure supply chain progress is captured accurately.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
