### PR TITLE
Correct broken link to Tanzu CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![codecov](https://codecov.io/gh/vmware-tanzu/apps-cli-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/vmware-tanzu/apps-cli-plugin)
 
 
-Apps plugin for [Tanzu CLI](https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli#installation) provides the ability to create, view, update, and delete application workloads on any Kubernetes cluster that has [Cartographer](https://cartographer.sh/) installed. It also provides commands to list and view ClusterSupplychain resources.
+Apps plugin for [Tanzu CLI](https://github.com/vmware-tanzu/tanzu-cli#installation) provides the ability to create, view, update, and delete application workloads on any Kubernetes cluster that has [Cartographer](https://cartographer.sh/) installed. It also provides commands to list and view ClusterSupplychain resources.
 
 ### <a id='About'></a>About Workloads and ClusterSupplychain
 
@@ -23,7 +23,7 @@ For further information about Cartographer resources, read the [official docs](h
 
 ## Getting Started
 ### Prerequisites
-[Tanzu CLI](https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli#installation) is required to use the `Apps` CLI plugin.
+[Tanzu CLI](https://github.com/vmware-tanzu/tanzu-cli#installation) is required to use the `Apps` CLI plugin.
 
 ### From a pre-built distribution
 Download the `tanzu-apps-plugin-<OS>-amd64-${VERSION}.tar.gz` from the most recent release listed on the [Apps Plugin for the Tanzu CLI releases](https://github.com/vmware-tanzu/apps-cli-plugin/releases) page.


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
The current Links to the Tanzu CLI are broken. It Redirect to a installation section of a none existing folder of the archived repository of the tanzu-framework.
I guess it got moved to a separated repository so I updated it to point to installation section of the Tanzu CLI repository instead.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #
Fixes the broken links
### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
